### PR TITLE
fix: generate webpbMeta as instance method reading this

### DIFF
--- a/plugin/internal/template/ts/message.body.tmpl
+++ b/plugin/internal/template/ts/message.body.tmpl
@@ -16,7 +16,6 @@ export class {{.className}}{{if .sub_type}}<T extends {{.sub_type}} = {{.sub_typ
   {{.name}}{{if not .default}}{{if .optional}}?{{else}}!{{end}}{{end}}: {{.type}}{{if .optional}} | null{{end}}{{if .default}} = {{.default}}{{end}};
   {{- end}}
 {{- end}}
-  webpbMeta: () => Webpb.WebpbMeta;
 {{- if hasContent .sub_type_prop}}
   static fromAliases: Record<string, (data?: unknown) => {{.className}}> = {};
 {{- end}}
@@ -44,21 +43,23 @@ export class {{.className}}{{if .sub_type}}<T extends {{.sub_type}} = {{.sub_typ
     {{- end}}
   {{- end}}
 {{- end}}
-    this.webpbMeta = () =>
-      ({
-        class: "{{.className}}",
-        context: "{{.context}}",
-        method: "{{.method}}",
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: {{.className}}.CLASS,
+      context: {{.className}}.CONTEXT,
+      method: {{.className}}.METHOD,
 {{- if hasContent .path}}
-        path: `{{- if index .path "url"}}{{index .path "url"}}{{end}}{{- if hasContent (index .path "queries")}}${Webpb.query("?", {
+      path: `{{- if index .path "url"}}{{index .path "url"}}{{end}}{{- if hasContent (index .path "queries")}}${Webpb.query("?", {
 {{- range $i, $q := index .path "queries"}}
-          "{{$q.key}}": {{$q.value}},
+        "{{$q.key}}": {{$q.value}},
 {{- end}}
-        })}{{end}}`,
+      })}{{end}}`,
 {{- else}}
-        path: "",
+      path: "",
 {{- end}}
-      } as Webpb.WebpbMeta);
+    };
   }
 
   static create(p?: I{{.className}}): {{.className}} {

--- a/plugin/internal/tsgen/message.go
+++ b/plugin/internal/tsgen/message.go
@@ -274,9 +274,9 @@ func (g *MessageGenerator) getQueries(group commons.SegmentGroup) []map[string]s
 
 func (g *MessageGenerator) getter(value string) string {
 	if strings.Contains(value, ".") {
-		return `Webpb.getter(p, "` + value + `")`
+		return `Webpb.getter(this, "` + value + `")`
 	}
-	return "p?." + value
+	return "this." + value
 }
 
 func (g *MessageGenerator) getFields(descriptor protoreflect.MessageDescriptor) []map[string]any {

--- a/plugin/testdata/ts/proto2_alias_skip/AliasSkipProto.ts
+++ b/plugin/testdata/ts/proto2_alias_skip/AliasSkipProto.ts
@@ -12,7 +12,6 @@ export interface IAliasSkip {
 export class AliasSkip implements IAliasSkip, Webpb.WebpbMessage {
   b!: number;
   a!: number;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "AliasSkip";
   static CONTEXT = "";
@@ -21,13 +20,15 @@ export class AliasSkip implements IAliasSkip, Webpb.WebpbMessage {
 
   protected constructor(p?: IAliasSkip) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "AliasSkip",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: AliasSkip.CLASS,
+      context: AliasSkip.CONTEXT,
+      method: AliasSkip.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IAliasSkip): AliasSkip {

--- a/plugin/testdata/ts/proto2_auto_alias/AliasReserveProto.ts
+++ b/plugin/testdata/ts/proto2_auto_alias/AliasReserveProto.ts
@@ -13,7 +13,6 @@ export class AliasReserveParent
   implements IAliasReserveParent, Webpb.WebpbMessage
 {
   foo_1!: number;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "AliasReserveParent";
   static CONTEXT = "";
@@ -22,13 +21,15 @@ export class AliasReserveParent
 
   protected constructor(p?: IAliasReserveParent) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "AliasReserveParent",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: AliasReserveParent.CLASS,
+      context: AliasReserveParent.CONTEXT,
+      method: AliasReserveParent.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IAliasReserveParent): AliasReserveParent {
@@ -59,7 +60,6 @@ export class AliasReserveChild
   implements IAliasReserveChild, Webpb.WebpbMessage
 {
   foo_2!: number;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "AliasReserveChild";
   static CONTEXT = "";
@@ -69,13 +69,15 @@ export class AliasReserveChild
   protected constructor(p?: IAliasReserveChild) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "AliasReserveChild",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: AliasReserveChild.CLASS,
+      context: AliasReserveChild.CONTEXT,
+      method: AliasReserveChild.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IAliasReserveChild): AliasReserveChild {

--- a/plugin/testdata/ts/proto2_auto_alias/ExtendsProto.ts
+++ b/plugin/testdata/ts/proto2_auto_alias/ExtendsProto.ts
@@ -11,7 +11,6 @@ export interface ILevel3 {
 
 export class Level3 implements ILevel3, Webpb.WebpbMessage {
   foo_1!: number;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level3";
   static CONTEXT = "";
@@ -20,13 +19,15 @@ export class Level3 implements ILevel3, Webpb.WebpbMessage {
 
   protected constructor(p?: ILevel3) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Level3",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level3.CLASS,
+      context: Level3.CONTEXT,
+      method: Level3.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel3): Level3 {
@@ -56,7 +57,6 @@ export class Level2
   implements ILevel2, Webpb.WebpbMessage
 {
   foo_2!: number;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level2";
   static CONTEXT = "";
@@ -66,13 +66,15 @@ export class Level2
   protected constructor(p?: ILevel2) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Level2",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level2.CLASS,
+      context: Level2.CONTEXT,
+      method: Level2.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel2): Level2 {
@@ -106,7 +108,6 @@ export class Level1
 {
   foo_3!: number;
   foo_4!: number;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level1";
   static CONTEXT = "";
@@ -116,13 +117,15 @@ export class Level1
   protected constructor(p?: ILevel1) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Level1",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level1.CLASS,
+      context: Level1.CONTEXT,
+      method: Level1.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel1): Level1 {

--- a/plugin/testdata/ts/proto2_auto_alias/FieldOptsProto.ts
+++ b/plugin/testdata/ts/proto2_auto_alias/FieldOptsProto.ts
@@ -10,7 +10,6 @@ export interface ILevel3 {
 
 export class Level3 implements ILevel3, Webpb.WebpbMessage {
   test1!: number;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level3";
   static CONTEXT = "";
@@ -19,13 +18,15 @@ export class Level3 implements ILevel3, Webpb.WebpbMessage {
 
   protected constructor(p?: ILevel3) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Level3",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level3.CLASS,
+      context: Level3.CONTEXT,
+      method: Level3.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel3): Level3 {
@@ -51,7 +52,6 @@ export class Level2 implements ILevel2, Webpb.WebpbMessage {
   test1!: number;
   test2!: ILevel3;
   test3!: ILevel3[];
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level2";
   static CONTEXT = "";
@@ -62,13 +62,15 @@ export class Level2 implements ILevel2, Webpb.WebpbMessage {
     Webpb.assign(p, this, []);
     p?.test2 && (this.test2 = Level3.create(p.test2));
     p?.test3 && (this.test3 = p.test3.map((x) => Level3.create(x)));
-    this.webpbMeta = () =>
-      ({
-        class: "Level2",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level2.CLASS,
+      context: Level2.CONTEXT,
+      method: Level2.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel2): Level2 {
@@ -112,7 +114,6 @@ export class Level1 implements ILevel1, Webpb.WebpbMessage {
   test4!: ILevel3;
   test5!: Record<number, ILevel3>;
   test6!: Record<string, ILevel3>;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level1";
   static CONTEXT = "";
@@ -128,13 +129,15 @@ export class Level1 implements ILevel1, Webpb.WebpbMessage {
       (this.test5 = Webpb.mapValues(p.test5, (x) => Level3.create(x)));
     p?.test6 &&
       (this.test6 = Webpb.mapValues(p.test6, (x) => Level3.create(x)));
-    this.webpbMeta = () =>
-      ({
-        class: "Level1",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level1.CLASS,
+      context: Level1.CONTEXT,
+      method: Level1.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel1): Level1 {

--- a/plugin/testdata/ts/proto2_auto_alias/FileOptsProto.ts
+++ b/plugin/testdata/ts/proto2_auto_alias/FileOptsProto.ts
@@ -10,7 +10,6 @@ export interface ILevel3 {
 
 export class Level3 implements ILevel3, Webpb.WebpbMessage {
   test1!: number;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level3";
   static CONTEXT = "";
@@ -19,13 +18,15 @@ export class Level3 implements ILevel3, Webpb.WebpbMessage {
 
   protected constructor(p?: ILevel3) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Level3",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level3.CLASS,
+      context: Level3.CONTEXT,
+      method: Level3.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel3): Level3 {
@@ -56,7 +57,6 @@ export class Level2 implements ILevel2, Webpb.WebpbMessage {
   test1!: number;
   test2!: ILevel3;
   test3!: ILevel3[];
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level2";
   static CONTEXT = "";
@@ -67,13 +67,15 @@ export class Level2 implements ILevel2, Webpb.WebpbMessage {
     Webpb.assign(p, this, []);
     p?.test2 && (this.test2 = Level3.create(p.test2));
     p?.test3 && (this.test3 = p.test3.map((x) => Level3.create(x)));
-    this.webpbMeta = () =>
-      ({
-        class: "Level2",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level2.CLASS,
+      context: Level2.CONTEXT,
+      method: Level2.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel2): Level2 {
@@ -122,7 +124,6 @@ export class Level1 implements ILevel1, Webpb.WebpbMessage {
   test4!: ILevel3;
   test5!: Record<number, ILevel3>;
   test6!: Record<string, ILevel3>;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level1";
   static CONTEXT = "";
@@ -138,13 +139,15 @@ export class Level1 implements ILevel1, Webpb.WebpbMessage {
       (this.test5 = Webpb.mapValues(p.test5, (x) => Level3.create(x)));
     p?.test6 &&
       (this.test6 = Webpb.mapValues(p.test6, (x) => Level3.create(x)));
-    this.webpbMeta = () =>
-      ({
-        class: "Level1",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level1.CLASS,
+      context: Level1.CONTEXT,
+      method: Level1.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel1): Level1 {

--- a/plugin/testdata/ts/proto2_auto_alias/MessageOptsProto.ts
+++ b/plugin/testdata/ts/proto2_auto_alias/MessageOptsProto.ts
@@ -10,7 +10,6 @@ export interface ILevel3 {
 
 export class Level3 implements ILevel3, Webpb.WebpbMessage {
   test1!: number;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level3";
   static CONTEXT = "";
@@ -19,13 +18,15 @@ export class Level3 implements ILevel3, Webpb.WebpbMessage {
 
   protected constructor(p?: ILevel3) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Level3",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level3.CLASS,
+      context: Level3.CONTEXT,
+      method: Level3.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel3): Level3 {
@@ -56,7 +57,6 @@ export class Level2 implements ILevel2, Webpb.WebpbMessage {
   test1!: number;
   test2!: ILevel3;
   test3!: ILevel3[];
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level2";
   static CONTEXT = "";
@@ -67,13 +67,15 @@ export class Level2 implements ILevel2, Webpb.WebpbMessage {
     Webpb.assign(p, this, []);
     p?.test2 && (this.test2 = Level3.create(p.test2));
     p?.test3 && (this.test3 = p.test3.map((x) => Level3.create(x)));
-    this.webpbMeta = () =>
-      ({
-        class: "Level2",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level2.CLASS,
+      context: Level2.CONTEXT,
+      method: Level2.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel2): Level2 {
@@ -111,7 +113,6 @@ export class Level1 implements ILevel1, Webpb.WebpbMessage {
   test4!: ILevel3;
   test5!: Record<number, ILevel3>;
   test6!: Record<string, ILevel3>;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level1";
   static CONTEXT = "";
@@ -127,13 +128,15 @@ export class Level1 implements ILevel1, Webpb.WebpbMessage {
       (this.test5 = Webpb.mapValues(p.test5, (x) => Level3.create(x)));
     p?.test6 &&
       (this.test6 = Webpb.mapValues(p.test6, (x) => Level3.create(x)));
-    this.webpbMeta = () =>
-      ({
-        class: "Level1",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level1.CLASS,
+      context: Level1.CONTEXT,
+      method: Level1.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel1): Level1 {

--- a/plugin/testdata/ts/proto2_auto_alias/WebpbOptsProto.ts
+++ b/plugin/testdata/ts/proto2_auto_alias/WebpbOptsProto.ts
@@ -10,7 +10,6 @@ export interface ILevel3 {
 
 export class Level3 implements ILevel3, Webpb.WebpbMessage {
   test1!: number;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level3";
   static CONTEXT = "";
@@ -19,13 +18,15 @@ export class Level3 implements ILevel3, Webpb.WebpbMessage {
 
   protected constructor(p?: ILevel3) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Level3",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level3.CLASS,
+      context: Level3.CONTEXT,
+      method: Level3.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel3): Level3 {
@@ -56,7 +57,6 @@ export class Level2 implements ILevel2, Webpb.WebpbMessage {
   test1!: number;
   test2!: ILevel3;
   test3!: ILevel3[];
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level2";
   static CONTEXT = "";
@@ -67,13 +67,15 @@ export class Level2 implements ILevel2, Webpb.WebpbMessage {
     Webpb.assign(p, this, []);
     p?.test2 && (this.test2 = Level3.create(p.test2));
     p?.test3 && (this.test3 = p.test3.map((x) => Level3.create(x)));
-    this.webpbMeta = () =>
-      ({
-        class: "Level2",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level2.CLASS,
+      context: Level2.CONTEXT,
+      method: Level2.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel2): Level2 {
@@ -122,7 +124,6 @@ export class Level1 implements ILevel1, Webpb.WebpbMessage {
   test4!: ILevel3;
   test5!: Record<number, ILevel3>;
   test6!: Record<string, ILevel3>;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level1";
   static CONTEXT = "";
@@ -138,13 +139,15 @@ export class Level1 implements ILevel1, Webpb.WebpbMessage {
       (this.test5 = Webpb.mapValues(p.test5, (x) => Level3.create(x)));
     p?.test6 &&
       (this.test6 = Webpb.mapValues(p.test6, (x) => Level3.create(x)));
-    this.webpbMeta = () =>
-      ({
-        class: "Level1",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level1.CLASS,
+      context: Level1.CONTEXT,
+      method: Level1.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel1): Level1 {

--- a/plugin/testdata/ts/proto2_core_codegen/IgnoredProto.ts
+++ b/plugin/testdata/ts/proto2_core_codegen/IgnoredProto.ts
@@ -10,7 +10,6 @@ export interface IIgnoreTest {
 
 export class IgnoreTest implements IIgnoreTest, Webpb.WebpbMessage {
   test1!: number;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "IgnoreTest";
   static CONTEXT = "";
@@ -19,13 +18,15 @@ export class IgnoreTest implements IIgnoreTest, Webpb.WebpbMessage {
 
   protected constructor(p?: IIgnoreTest) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "IgnoreTest",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: IgnoreTest.CLASS,
+      context: IgnoreTest.CONTEXT,
+      method: IgnoreTest.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IIgnoreTest): IgnoreTest {

--- a/plugin/testdata/ts/proto2_core_codegen/Include2Proto.ts
+++ b/plugin/testdata/ts/proto2_core_codegen/Include2Proto.ts
@@ -10,7 +10,6 @@ export interface IMessage {
 
 export class Message implements IMessage, Webpb.WebpbMessage {
   id!: number;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Message";
   static CONTEXT = "";
@@ -19,13 +18,15 @@ export class Message implements IMessage, Webpb.WebpbMessage {
 
   protected constructor(p?: IMessage) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Message",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Message.CLASS,
+      context: Message.CONTEXT,
+      method: Message.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IMessage): Message {
@@ -48,7 +49,6 @@ export namespace Message {
 
   export class Nested implements INested, Webpb.WebpbMessage {
     test1!: number;
-    webpbMeta: () => Webpb.WebpbMeta;
 
     static CLASS = "Nested";
     static CONTEXT = "";
@@ -57,13 +57,15 @@ export namespace Message {
 
     protected constructor(p?: INested) {
       Webpb.assign(p, this, []);
-      this.webpbMeta = () =>
-        ({
-          class: "Nested",
-          context: "",
-          method: "",
-          path: "",
-        }) as Webpb.WebpbMeta;
+    }
+
+    webpbMeta(): Webpb.WebpbMeta {
+      return {
+        class: Nested.CLASS,
+        context: Nested.CONTEXT,
+        method: Nested.METHOD,
+        path: "",
+      };
     }
 
     static create(p?: INested): Nested {

--- a/plugin/testdata/ts/proto2_core_codegen/IncludeProto.ts
+++ b/plugin/testdata/ts/proto2_core_codegen/IncludeProto.ts
@@ -22,7 +22,6 @@ export interface IMessage {
 
 export class Message implements IMessage, Webpb.WebpbMessage {
   id!: number;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Message";
   static CONTEXT = "";
@@ -31,13 +30,15 @@ export class Message implements IMessage, Webpb.WebpbMessage {
 
   protected constructor(p?: IMessage) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Message",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Message.CLASS,
+      context: Message.CONTEXT,
+      method: Message.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IMessage): Message {
@@ -60,7 +61,6 @@ export namespace Message {
 
   export class Nested implements INested, Webpb.WebpbMessage {
     test1!: number;
-    webpbMeta: () => Webpb.WebpbMeta;
 
     static CLASS = "Nested";
     static CONTEXT = "";
@@ -69,13 +69,15 @@ export namespace Message {
 
     protected constructor(p?: INested) {
       Webpb.assign(p, this, []);
-      this.webpbMeta = () =>
-        ({
-          class: "Nested",
-          context: "",
-          method: "",
-          path: "",
-        }) as Webpb.WebpbMeta;
+    }
+
+    webpbMeta(): Webpb.WebpbMeta {
+      return {
+        class: Nested.CLASS,
+        context: Nested.CONTEXT,
+        method: Nested.METHOD,
+        path: "",
+      };
     }
 
     static create(p?: INested): Nested {

--- a/plugin/testdata/ts/proto2_core_codegen/TestProto.ts
+++ b/plugin/testdata/ts/proto2_core_codegen/TestProto.ts
@@ -54,7 +54,6 @@ export interface ITest1 {
 export class Test1 implements ITest1, Webpb.WebpbMessage {
   test1!: string;
   test2!: number;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Test1";
   static CONTEXT = "/test";
@@ -63,19 +62,21 @@ export class Test1 implements ITest1, Webpb.WebpbMessage {
 
   protected constructor(p?: ITest1) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Test1",
-        context: "/test",
-        method: "GET",
-        path: `/test${Webpb.query("?", {
-          a: "123",
-          b: p?.test1,
-          c: "321",
-          d: p?.test2,
-          e: "456",
-        })}`,
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Test1.CLASS,
+      context: Test1.CONTEXT,
+      method: Test1.METHOD,
+      path: `/test${Webpb.query("?", {
+        a: "123",
+        b: this.test1,
+        c: "321",
+        d: this.test2,
+        e: "456",
+      })}`,
+    };
   }
 
   static create(p?: ITest1): Test1 {
@@ -103,7 +104,6 @@ export class Test2 extends AbstractClass implements ITest2, Webpb.WebpbMessage {
   test2!: string;
   test3!: ITest6;
   test4!: Record<number, ITest1>;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Test2";
   static CONTEXT = "/test";
@@ -116,17 +116,19 @@ export class Test2 extends AbstractClass implements ITest2, Webpb.WebpbMessage {
     Webpb.assign(p, this, []);
     p?.test3 && (this.test3 = Test6.create(p.test3));
     p?.test4 && (this.test4 = Webpb.mapValues(p.test4, (x) => Test1.create(x)));
-    this.webpbMeta = () =>
-      ({
-        class: "Test2",
-        context: "/test",
-        method: "GET",
-        path: `/test/${p?.test2}${Webpb.query("?", {
-          data1: Webpb.getter(p, "test3.test1"),
-          data2: Webpb.getter(p, "test3.test2"),
-          id: p?.test1,
-        })}`,
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Test2.CLASS,
+      context: Test2.CONTEXT,
+      method: Test2.METHOD,
+      path: `/test/${this.test2}${Webpb.query("?", {
+        data1: Webpb.getter(this, "test3.test1"),
+        data2: Webpb.getter(this, "test3.test2"),
+        id: this.test1,
+      })}`,
+    };
   }
 
   static create(p?: ITest2): Test2 {
@@ -157,7 +159,6 @@ export class Test4 implements ITest4, Webpb.WebpbMessage {
   test2!: number;
   test3!: string;
   test4!: string[];
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Test4";
   static CONTEXT = "";
@@ -166,13 +167,15 @@ export class Test4 implements ITest4, Webpb.WebpbMessage {
 
   protected constructor(p?: ITest4) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Test4",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Test4.CLASS,
+      context: Test4.CONTEXT,
+      method: Test4.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ITest4): Test4 {
@@ -203,7 +206,6 @@ export interface ITest6 {
 export class Test6 implements ITest6, Webpb.WebpbMessage {
   test1!: string;
   test2?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Test6";
   static CONTEXT = "";
@@ -212,13 +214,15 @@ export class Test6 implements ITest6, Webpb.WebpbMessage {
 
   protected constructor(p?: ITest6) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Test6",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Test6.CLASS,
+      context: Test6.CONTEXT,
+      method: Test6.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ITest6): Test6 {
@@ -276,7 +280,6 @@ export class Test implements ITest, Webpb.WebpbMessage {
   test17!: Test.ITest17;
   test18: number = 123;
   test19: string = "test19";
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Test";
   static CONTEXT = "/test";
@@ -299,13 +302,15 @@ export class Test implements ITest, Webpb.WebpbMessage {
       (this.test13 = p.test13.map((x) => Include2Proto.Message.create(x)));
     p?.test14 && (this.test14 = Include2Proto.Message.Nested.create(p.test14));
     p?.test17 && (this.test17 = Test.Test17.create(p.test17));
-    this.webpbMeta = () =>
-      ({
-        class: "Test",
-        context: "/test",
-        method: "GET",
-        path: `/test/${p?.test1}`,
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Test.CLASS,
+      context: Test.CONTEXT,
+      method: Test.METHOD,
+      path: `/test/${this.test1}`,
+    };
   }
 
   static create(p?: ITest): Test {
@@ -347,7 +352,6 @@ export namespace Test {
 
   export class NestedTest implements INestedTest, Webpb.WebpbMessage {
     test1!: number;
-    webpbMeta: () => Webpb.WebpbMeta;
 
     static CLASS = "NestedTest";
     static CONTEXT = "/test";
@@ -356,13 +360,15 @@ export namespace Test {
 
     protected constructor(p?: INestedTest) {
       Webpb.assign(p, this, []);
-      this.webpbMeta = () =>
-        ({
-          class: "NestedTest",
-          context: "/test",
-          method: "GET",
-          path: `/test/nested/${p?.test1}`,
-        }) as Webpb.WebpbMeta;
+    }
+
+    webpbMeta(): Webpb.WebpbMeta {
+      return {
+        class: NestedTest.CLASS,
+        context: NestedTest.CONTEXT,
+        method: NestedTest.METHOD,
+        path: `/test/nested/${this.test1}`,
+      };
     }
 
     static create(p?: INestedTest): NestedTest {
@@ -384,7 +390,6 @@ export namespace Test {
 
   export class Test17 implements ITest17, Webpb.WebpbMessage {
     test!: string;
-    webpbMeta: () => Webpb.WebpbMeta;
 
     static CLASS = "Test17";
     static CONTEXT = "";
@@ -393,13 +398,15 @@ export namespace Test {
 
     protected constructor(p?: ITest17) {
       Webpb.assign(p, this, []);
-      this.webpbMeta = () =>
-        ({
-          class: "Test17",
-          context: "",
-          method: "",
-          path: "",
-        }) as Webpb.WebpbMeta;
+    }
+
+    webpbMeta(): Webpb.WebpbMeta {
+      return {
+        class: Test17.CLASS,
+        context: Test17.CONTEXT,
+        method: Test17.METHOD,
+        path: "",
+      };
     }
 
     static create(p?: ITest17): Test17 {

--- a/plugin/testdata/ts/proto2_enumeration/MapValueTestProto.ts
+++ b/plugin/testdata/ts/proto2_enumeration/MapValueTestProto.ts
@@ -24,7 +24,6 @@ export interface IMapValueTestPb {
 
 export class MapValueTestPb implements IMapValueTestPb, Webpb.WebpbMessage {
   sort!: Record<string, Direction>;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "MapValueTestPb";
   static CONTEXT = "";
@@ -33,13 +32,15 @@ export class MapValueTestPb implements IMapValueTestPb, Webpb.WebpbMessage {
 
   protected constructor(p?: IMapValueTestPb) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "MapValueTestPb",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: MapValueTestPb.CLASS,
+      context: MapValueTestPb.CONTEXT,
+      method: MapValueTestPb.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IMapValueTestPb): MapValueTestPb {

--- a/plugin/testdata/ts/proto2_errors/BadAnnotationProto.ts
+++ b/plugin/testdata/ts/proto2_errors/BadAnnotationProto.ts
@@ -12,7 +12,6 @@ export interface IBadAnnotation {
 export class BadAnnotation implements IBadAnnotation, Webpb.WebpbMessage {
   foo_2!: number;
   bar_2!: string;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "BadAnnotation";
   static CONTEXT = "";
@@ -21,13 +20,15 @@ export class BadAnnotation implements IBadAnnotation, Webpb.WebpbMessage {
 
   protected constructor(p?: IBadAnnotation) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "BadAnnotation",
-        context: "",
-        method: "",
-        path: "",
-      } as Webpb.WebpbMeta);
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: BadAnnotation.CLASS,
+      context: BadAnnotation.CONTEXT,
+      method: BadAnnotation.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IBadAnnotation): BadAnnotation {

--- a/plugin/testdata/ts/proto2_errors/BadClassOrInterfaceProto.ts
+++ b/plugin/testdata/ts/proto2_errors/BadClassOrInterfaceProto.ts
@@ -12,7 +12,6 @@ export interface IBadAnnotation extends ....IBadClassOrInterface {
 export class BadAnnotation extends ....BadClassOrInterface implements IBadAnnotation, Webpb.WebpbMessage {
   foo_2!: number;
   bar_2!: string;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "BadAnnotation";
   static CONTEXT = "";
@@ -22,13 +21,15 @@ export class BadAnnotation extends ....BadClassOrInterface implements IBadAnnota
   protected constructor(p?: IBadAnnotation) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "BadAnnotation",
-        context: "",
-        method: "",
-        path: "",
-      } as Webpb.WebpbMeta);
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: BadAnnotation.CLASS,
+      context: BadAnnotation.CONTEXT,
+      method: BadAnnotation.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IBadAnnotation): BadAnnotation {

--- a/plugin/testdata/ts/proto2_errors/BadExtendsProto.ts
+++ b/plugin/testdata/ts/proto2_errors/BadExtendsProto.ts
@@ -10,7 +10,6 @@ export interface IBadExtends extends IBadExtendsFoo<"foo"> {
 
 export class BadExtends extends BadExtendsFoo<"foo"> implements IBadExtends, Webpb.WebpbMessage {
   value!: number;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "BadExtends";
   static CONTEXT = "";
@@ -20,13 +19,15 @@ export class BadExtends extends BadExtendsFoo<"foo"> implements IBadExtends, Web
   protected constructor(p?: IBadExtends) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "BadExtends",
-        context: "",
-        method: "",
-        path: "",
-      } as Webpb.WebpbMeta);
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: BadExtends.CLASS,
+      context: BadExtends.CONTEXT,
+      method: BadExtends.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IBadExtends): BadExtends {

--- a/plugin/testdata/ts/proto2_errors/ImportPathNotFoundProto.ts
+++ b/plugin/testdata/ts/proto2_errors/ImportPathNotFoundProto.ts
@@ -13,7 +13,6 @@ export interface IImportPathNotFound extends BadImport.IExtends {
 export class ImportPathNotFound extends BadImport.Extends implements IImportPathNotFound, Webpb.WebpbMessage {
   foo_2!: number;
   bar_2!: string;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "ImportPathNotFound";
   static CONTEXT = "";
@@ -23,13 +22,15 @@ export class ImportPathNotFound extends BadImport.Extends implements IImportPath
   protected constructor(p?: IImportPathNotFound) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "ImportPathNotFound",
-        context: "",
-        method: "",
-        path: "",
-      } as Webpb.WebpbMeta);
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: ImportPathNotFound.CLASS,
+      context: ImportPathNotFound.CONTEXT,
+      method: ImportPathNotFound.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IImportPathNotFound): ImportPathNotFound {

--- a/plugin/testdata/ts/proto2_errors/TestProto.ts
+++ b/plugin/testdata/ts/proto2_errors/TestProto.ts
@@ -10,7 +10,6 @@ export interface ITest {
 
 export class Test implements ITest, Webpb.WebpbMessage {
   test1!: number;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Test";
   static CONTEXT = "";
@@ -19,13 +18,15 @@ export class Test implements ITest, Webpb.WebpbMessage {
 
   protected constructor(p?: ITest) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Test",
-        context: "",
-        method: "",
-        path: "",
-      } as Webpb.WebpbMeta);
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Test.CLASS,
+      context: Test.CONTEXT,
+      method: Test.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ITest): Test {

--- a/plugin/testdata/ts/proto2_generator_options/HttpMethodsProto.ts
+++ b/plugin/testdata/ts/proto2_generator_options/HttpMethodsProto.ts
@@ -12,7 +12,6 @@ export interface IPostRequest {
 export class PostRequest implements IPostRequest, Webpb.WebpbMessage {
   id!: number;
   body?: string | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "PostRequest";
   static CONTEXT = "/api";
@@ -21,13 +20,15 @@ export class PostRequest implements IPostRequest, Webpb.WebpbMessage {
 
   protected constructor(p?: IPostRequest) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "PostRequest",
-        context: "/api",
-        method: "POST",
-        path: `/items/${p?.id}`,
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: PostRequest.CLASS,
+      context: PostRequest.CONTEXT,
+      method: PostRequest.METHOD,
+      path: `/items/${this.id}`,
+    };
   }
 
   static create(p?: IPostRequest): PostRequest {
@@ -51,7 +52,6 @@ export interface IPutRequest {
 export class PutRequest implements IPutRequest, Webpb.WebpbMessage {
   id!: number;
   body!: string;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "PutRequest";
   static CONTEXT = "/api";
@@ -60,13 +60,15 @@ export class PutRequest implements IPutRequest, Webpb.WebpbMessage {
 
   protected constructor(p?: IPutRequest) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "PutRequest",
-        context: "/api",
-        method: "PUT",
-        path: `/items/${p?.id}`,
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: PutRequest.CLASS,
+      context: PutRequest.CONTEXT,
+      method: PutRequest.METHOD,
+      path: `/items/${this.id}`,
+    };
   }
 
   static create(p?: IPutRequest): PutRequest {
@@ -88,7 +90,6 @@ export interface IDeleteRequest {
 
 export class DeleteRequest implements IDeleteRequest, Webpb.WebpbMessage {
   id!: number;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "DeleteRequest";
   static CONTEXT = "/api";
@@ -97,13 +98,15 @@ export class DeleteRequest implements IDeleteRequest, Webpb.WebpbMessage {
 
   protected constructor(p?: IDeleteRequest) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "DeleteRequest",
-        context: "/api",
-        method: "DELETE",
-        path: `/items/${p?.id}`,
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: DeleteRequest.CLASS,
+      context: DeleteRequest.CONTEXT,
+      method: DeleteRequest.METHOD,
+      path: `/items/${this.id}`,
+    };
   }
 
   static create(p?: IDeleteRequest): DeleteRequest {

--- a/plugin/testdata/ts/proto2_generator_options/PrimitiveTypesProto.ts
+++ b/plugin/testdata/ts/proto2_generator_options/PrimitiveTypesProto.ts
@@ -30,7 +30,6 @@ export class PrimitiveTypes implements IPrimitiveTypes, Webpb.WebpbMessage {
   sfixed32_field!: number;
   sfixed64_field!: number;
   repeated_float!: number[];
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "PrimitiveTypes";
   static CONTEXT = "";
@@ -39,13 +38,15 @@ export class PrimitiveTypes implements IPrimitiveTypes, Webpb.WebpbMessage {
 
   protected constructor(p?: IPrimitiveTypes) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "PrimitiveTypes",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: PrimitiveTypes.CLASS,
+      context: PrimitiveTypes.CONTEXT,
+      method: PrimitiveTypes.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IPrimitiveTypes): PrimitiveTypes {

--- a/plugin/testdata/ts/proto2_generator_options/RepeatedEnumProto.ts
+++ b/plugin/testdata/ts/proto2_generator_options/RepeatedEnumProto.ts
@@ -26,7 +26,6 @@ export interface IRepeatedEnum {
 export class RepeatedEnum implements IRepeatedEnum, Webpb.WebpbMessage {
   status!: Status[];
   status_by_code!: Record<number, Status>;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "RepeatedEnum";
   static CONTEXT = "";
@@ -35,13 +34,15 @@ export class RepeatedEnum implements IRepeatedEnum, Webpb.WebpbMessage {
 
   protected constructor(p?: IRepeatedEnum) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "RepeatedEnum",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: RepeatedEnum.CLASS,
+      context: RepeatedEnum.CONTEXT,
+      method: RepeatedEnum.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IRepeatedEnum): RepeatedEnum {
@@ -68,7 +69,6 @@ export namespace RepeatedEnum {
   {
     key?: number | null;
     value?: Status | null;
-    webpbMeta: () => Webpb.WebpbMeta;
 
     static CLASS = "StatusByCodeEntry";
     static CONTEXT = "";
@@ -77,13 +77,15 @@ export namespace RepeatedEnum {
 
     protected constructor(p?: IStatusByCodeEntry) {
       Webpb.assign(p, this, []);
-      this.webpbMeta = () =>
-        ({
-          class: "StatusByCodeEntry",
-          context: "",
-          method: "",
-          path: "",
-        }) as Webpb.WebpbMeta;
+    }
+
+    webpbMeta(): Webpb.WebpbMeta {
+      return {
+        class: StatusByCodeEntry.CLASS,
+        context: StatusByCodeEntry.CONTEXT,
+        method: StatusByCodeEntry.METHOD,
+        path: "",
+      };
     }
 
     static create(p?: IStatusByCodeEntry): StatusByCodeEntry {

--- a/plugin/testdata/ts/proto2_generator_options/RepeatedFieldTypesProto.ts
+++ b/plugin/testdata/ts/proto2_generator_options/RepeatedFieldTypesProto.ts
@@ -16,7 +16,6 @@ export class RepeatedFieldTypes
   as_list!: string[];
   as_set!: string[];
   as_collection!: string[];
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "RepeatedFieldTypes";
   static CONTEXT = "";
@@ -25,13 +24,15 @@ export class RepeatedFieldTypes
 
   protected constructor(p?: IRepeatedFieldTypes) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "RepeatedFieldTypes",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: RepeatedFieldTypes.CLASS,
+      context: RepeatedFieldTypes.CONTEXT,
+      method: RepeatedFieldTypes.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IRepeatedFieldTypes): RepeatedFieldTypes {

--- a/plugin/testdata/ts/proto2_generator_options/Test10Proto.ts
+++ b/plugin/testdata/ts/proto2_generator_options/Test10Proto.ts
@@ -10,7 +10,6 @@ export interface ITest10 {
 
 export class Test10 implements ITest10, Webpb.WebpbMessage {
   test1!: number;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Test10";
   static CONTEXT = "";
@@ -19,13 +18,15 @@ export class Test10 implements ITest10, Webpb.WebpbMessage {
 
   protected constructor(p?: ITest10) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Test10",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Test10.CLASS,
+      context: Test10.CONTEXT,
+      method: Test10.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ITest10): Test10 {

--- a/plugin/testdata/ts/proto2_generator_options/Test11Proto.ts
+++ b/plugin/testdata/ts/proto2_generator_options/Test11Proto.ts
@@ -12,7 +12,6 @@ export interface ITest11 {
 export class Test11 implements ITest11, Webpb.WebpbMessage {
   test1!: number;
   test11!: ITest11;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Test11";
   static CONTEXT = "";
@@ -22,13 +21,15 @@ export class Test11 implements ITest11, Webpb.WebpbMessage {
   protected constructor(p?: ITest11) {
     Webpb.assign(p, this, []);
     p?.test11 && (this.test11 = Test11.create(p.test11));
-    this.webpbMeta = () =>
-      ({
-        class: "Test11",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Test11.CLASS,
+      context: Test11.CONTEXT,
+      method: Test11.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ITest11): Test11 {

--- a/plugin/testdata/ts/proto2_generator_options/Test1Proto.ts
+++ b/plugin/testdata/ts/proto2_generator_options/Test1Proto.ts
@@ -7,8 +7,6 @@ import * as Webpb from "webpb";
 export interface ITest {}
 
 export class Test implements ITest, Webpb.WebpbMessage {
-  webpbMeta: () => Webpb.WebpbMeta;
-
   static CLASS = "Test";
   static CONTEXT = "";
   static METHOD = "";
@@ -16,13 +14,15 @@ export class Test implements ITest, Webpb.WebpbMessage {
 
   protected constructor(p?: ITest) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Test",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Test.CLASS,
+      context: Test.CONTEXT,
+      method: Test.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ITest): Test {

--- a/plugin/testdata/ts/proto2_generator_options/Test2Proto.ts
+++ b/plugin/testdata/ts/proto2_generator_options/Test2Proto.ts
@@ -14,7 +14,6 @@ export class Test implements ITest, Webpb.WebpbMessage {
   test1!: number;
   test2!: boolean;
   isTest3!: boolean;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Test";
   static CONTEXT = "";
@@ -23,13 +22,15 @@ export class Test implements ITest, Webpb.WebpbMessage {
 
   protected constructor(p?: ITest) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Test",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Test.CLASS,
+      context: Test.CONTEXT,
+      method: Test.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ITest): Test {

--- a/plugin/testdata/ts/proto2_generator_options/Test3Proto.ts
+++ b/plugin/testdata/ts/proto2_generator_options/Test3Proto.ts
@@ -10,7 +10,6 @@ export interface ITest {
 
 export class Test implements ITest, Webpb.WebpbMessage {
   test1!: number;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Test";
   static CONTEXT = "";
@@ -19,13 +18,15 @@ export class Test implements ITest, Webpb.WebpbMessage {
 
   protected constructor(p?: ITest) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Test",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Test.CLASS,
+      context: Test.CONTEXT,
+      method: Test.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ITest): Test {

--- a/plugin/testdata/ts/proto2_generator_options/Test4Proto.ts
+++ b/plugin/testdata/ts/proto2_generator_options/Test4Proto.ts
@@ -10,7 +10,6 @@ export interface ITest {
 
 export class Test implements ITest, Webpb.WebpbMessage {
   test1!: string;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Test";
   static CONTEXT = "";
@@ -19,13 +18,15 @@ export class Test implements ITest, Webpb.WebpbMessage {
 
   protected constructor(p?: ITest) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Test",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Test.CLASS,
+      context: Test.CONTEXT,
+      method: Test.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ITest): Test {

--- a/plugin/testdata/ts/proto2_generator_options/Test9Proto.ts
+++ b/plugin/testdata/ts/proto2_generator_options/Test9Proto.ts
@@ -10,7 +10,6 @@ export interface ITest9 {
 
 export class Test9 implements ITest9, Webpb.WebpbMessage {
   test1!: string;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Test9";
   static CONTEXT = "";
@@ -19,13 +18,15 @@ export class Test9 implements ITest9, Webpb.WebpbMessage {
 
   protected constructor(p?: ITest9) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Test9",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Test9.CLASS,
+      context: Test9.CONTEXT,
+      method: Test9.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ITest9): Test9 {

--- a/plugin/testdata/ts/proto2_imports/ImportTestProto.ts
+++ b/plugin/testdata/ts/proto2_imports/ImportTestProto.ts
@@ -18,7 +18,6 @@ export class ImportTest
   foo_2!: number;
   bar_2!: string;
   no_package!: NoPackageProto.INoPackage;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "ImportTest";
   static CONTEXT = "";
@@ -30,13 +29,15 @@ export class ImportTest
     Webpb.assign(p, this, []);
     p?.no_package &&
       (this.no_package = NoPackageProto.NoPackage.create(p.no_package));
-    this.webpbMeta = () =>
-      ({
-        class: "ImportTest",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: ImportTest.CLASS,
+      context: ImportTest.CONTEXT,
+      method: ImportTest.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IImportTest): ImportTest {

--- a/plugin/testdata/ts/proto2_imports/NoPackageProto.ts
+++ b/plugin/testdata/ts/proto2_imports/NoPackageProto.ts
@@ -10,7 +10,6 @@ export interface INoPackageTest {
 
 export class NoPackageTest implements INoPackageTest, Webpb.WebpbMessage {
   foo!: number;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "NoPackageTest";
   static CONTEXT = "";
@@ -19,13 +18,15 @@ export class NoPackageTest implements INoPackageTest, Webpb.WebpbMessage {
 
   protected constructor(p?: INoPackageTest) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "NoPackageTest",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: NoPackageTest.CLASS,
+      context: NoPackageTest.CONTEXT,
+      method: NoPackageTest.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: INoPackageTest): NoPackageTest {
@@ -51,7 +52,6 @@ export class NoPackage implements INoPackage, Webpb.WebpbMessage {
   foo_1!: number;
   bar_1!: string;
   test!: INoPackageTest;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "NoPackage";
   static CONTEXT = "";
@@ -61,13 +61,15 @@ export class NoPackage implements INoPackage, Webpb.WebpbMessage {
   protected constructor(p?: INoPackage) {
     Webpb.assign(p, this, []);
     p?.test && (this.test = NoPackageTest.create(p.test));
-    this.webpbMeta = () =>
-      ({
-        class: "NoPackage",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: NoPackage.CLASS,
+      context: NoPackage.CONTEXT,
+      method: NoPackage.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: INoPackage): NoPackage {

--- a/plugin/testdata/ts/proto2_message_extends/Extends2Proto.ts
+++ b/plugin/testdata/ts/proto2_message_extends/Extends2Proto.ts
@@ -12,7 +12,6 @@ export interface IExtends {
 export class Extends implements IExtends, Webpb.WebpbMessage {
   foo_1!: number;
   bar_1!: string;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Extends";
   static CONTEXT = "";
@@ -21,13 +20,15 @@ export class Extends implements IExtends, Webpb.WebpbMessage {
 
   protected constructor(p?: IExtends) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Extends",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Extends.CLASS,
+      context: Extends.CONTEXT,
+      method: Extends.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IExtends): Extends {

--- a/plugin/testdata/ts/proto2_message_extends/ExtendsProto.ts
+++ b/plugin/testdata/ts/proto2_message_extends/ExtendsProto.ts
@@ -12,7 +12,6 @@ export interface IExtends {
 export class Extends implements IExtends, Webpb.WebpbMessage {
   foo_1!: number;
   bar_1!: string;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Extends";
   static CONTEXT = "";
@@ -21,13 +20,15 @@ export class Extends implements IExtends, Webpb.WebpbMessage {
 
   protected constructor(p?: IExtends) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Extends",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Extends.CLASS,
+      context: Extends.CONTEXT,
+      method: Extends.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IExtends): Extends {

--- a/plugin/testdata/ts/proto2_message_extends/MainProto.ts
+++ b/plugin/testdata/ts/proto2_message_extends/MainProto.ts
@@ -18,7 +18,6 @@ export class Main1
 {
   foo_2!: number;
   bar_2!: string;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Main1";
   static CONTEXT = "";
@@ -28,13 +27,15 @@ export class Main1
   protected constructor(p?: IMain1) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Main1",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Main1.CLASS,
+      context: Main1.CONTEXT,
+      method: Main1.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IMain1): Main1 {
@@ -61,7 +62,6 @@ export class Main2
 {
   foo_2!: number;
   bar_2!: string;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Main2";
   static CONTEXT = "";
@@ -71,13 +71,15 @@ export class Main2
   protected constructor(p?: IMain2) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Main2",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Main2.CLASS,
+      context: Main2.CONTEXT,
+      method: Main2.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IMain2): Main2 {
@@ -104,7 +106,6 @@ export class Main3
 {
   foo_2!: number;
   bar_2!: string;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Main3";
   static CONTEXT = "";
@@ -114,13 +115,15 @@ export class Main3
   protected constructor(p?: IMain3) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Main3",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Main3.CLASS,
+      context: Main3.CONTEXT,
+      method: Main3.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IMain3): Main3 {
@@ -144,7 +147,6 @@ export interface IMain4 extends ICustom {
 export class Main4 extends Custom implements IMain4, Webpb.WebpbMessage {
   foo_2!: number;
   bar_2!: string;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Main4";
   static CONTEXT = "";
@@ -154,13 +156,15 @@ export class Main4 extends Custom implements IMain4, Webpb.WebpbMessage {
   protected constructor(p?: IMain4) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Main4",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Main4.CLASS,
+      context: Main4.CONTEXT,
+      method: Main4.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IMain4): Main4 {

--- a/plugin/testdata/ts/proto2_message_extends/SubTypeSubValueProto.ts
+++ b/plugin/testdata/ts/proto2_message_extends/SubTypeSubValueProto.ts
@@ -40,7 +40,6 @@ export class SubTypeSubValueStringSuper
   implements ISubTypeSubValueStringSuper, Webpb.WebpbMessage
 {
   type!: string;
-  webpbMeta: () => Webpb.WebpbMeta;
   static fromAliases: Record<
     string,
     (data?: unknown) => SubTypeSubValueStringSuper
@@ -53,13 +52,15 @@ export class SubTypeSubValueStringSuper
 
   protected constructor(p?: ISubTypeSubValueStringSuper) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "SubTypeSubValueStringSuper",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: SubTypeSubValueStringSuper.CLASS,
+      context: SubTypeSubValueStringSuper.CONTEXT,
+      method: SubTypeSubValueStringSuper.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ISubTypeSubValueStringSuper): SubTypeSubValueStringSuper {
@@ -89,7 +90,6 @@ export class SubTypeSubValueSuper<
   implements ISubTypeSubValueSuper<T>, Webpb.WebpbMessage
 {
   type!: T;
-  webpbMeta: () => Webpb.WebpbMeta;
   static fromAliases: Record<string, (data?: unknown) => SubTypeSubValueSuper> =
     {};
 
@@ -100,13 +100,15 @@ export class SubTypeSubValueSuper<
 
   protected constructor(p?: ISubTypeSubValueSuper) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "SubTypeSubValueSuper",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: SubTypeSubValueSuper.CLASS,
+      context: SubTypeSubValueSuper.CONTEXT,
+      method: SubTypeSubValueSuper.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ISubTypeSubValueSuper): SubTypeSubValueSuper {
@@ -132,7 +134,6 @@ export class SubTypeSubValue0
   implements ISubTypeSubValue0, Webpb.WebpbMessage
 {
   value!: number;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "SubTypeSubValue0";
   static CONTEXT = "";
@@ -142,13 +143,15 @@ export class SubTypeSubValue0
   protected constructor(p?: ISubTypeSubValue0) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "SubTypeSubValue0",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: SubTypeSubValue0.CLASS,
+      context: SubTypeSubValue0.CONTEXT,
+      method: SubTypeSubValue0.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ISubTypeSubValue0): SubTypeSubValue0 {
@@ -173,7 +176,6 @@ export class SubTypeSubValue1
   implements ISubTypeSubValue1, Webpb.WebpbMessage
 {
   value!: number;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "SubTypeSubValue1";
   static CONTEXT = "";
@@ -183,13 +185,15 @@ export class SubTypeSubValue1
   protected constructor(p?: ISubTypeSubValue1) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "SubTypeSubValue1",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: SubTypeSubValue1.CLASS,
+      context: SubTypeSubValue1.CONTEXT,
+      method: SubTypeSubValue1.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ISubTypeSubValue1): SubTypeSubValue1 {
@@ -218,7 +222,6 @@ export class SubTypeSubValue2
   implements ISubTypeSubValue2, Webpb.WebpbMessage
 {
   value!: number;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "SubTypeSubValue2";
   static CONTEXT = "";
@@ -228,13 +231,15 @@ export class SubTypeSubValue2
   protected constructor(p?: ISubTypeSubValue2) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "SubTypeSubValue2",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: SubTypeSubValue2.CLASS,
+      context: SubTypeSubValue2.CONTEXT,
+      method: SubTypeSubValue2.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ISubTypeSubValue2): SubTypeSubValue2 {
@@ -256,7 +261,6 @@ export interface ISubTypeSubValue3 {
 
 export class SubTypeSubValue3 implements ISubTypeSubValue3, Webpb.WebpbMessage {
   value!: number;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "SubTypeSubValue3";
   static CONTEXT = "";
@@ -265,13 +269,15 @@ export class SubTypeSubValue3 implements ISubTypeSubValue3, Webpb.WebpbMessage {
 
   protected constructor(p?: ISubTypeSubValue3) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "SubTypeSubValue3",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: SubTypeSubValue3.CLASS,
+      context: SubTypeSubValue3.CONTEXT,
+      method: SubTypeSubValue3.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ISubTypeSubValue3): SubTypeSubValue3 {
@@ -296,7 +302,6 @@ export class SubTypeSubValue4
   implements ISubTypeSubValue4, Webpb.WebpbMessage
 {
   value!: number;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "SubTypeSubValue4";
   static CONTEXT = "";
@@ -306,13 +311,15 @@ export class SubTypeSubValue4
   protected constructor(p?: ISubTypeSubValue4) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "SubTypeSubValue4",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: SubTypeSubValue4.CLASS,
+      context: SubTypeSubValue4.CONTEXT,
+      method: SubTypeSubValue4.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ISubTypeSubValue4): SubTypeSubValue4 {
@@ -337,7 +344,6 @@ export class SubTypeSubValue5
   implements ISubTypeSubValue5, Webpb.WebpbMessage
 {
   value!: number;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "SubTypeSubValue5";
   static CONTEXT = "";
@@ -347,13 +353,15 @@ export class SubTypeSubValue5
   protected constructor(p?: ISubTypeSubValue5) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "SubTypeSubValue5",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: SubTypeSubValue5.CLASS,
+      context: SubTypeSubValue5.CONTEXT,
+      method: SubTypeSubValue5.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ISubTypeSubValue5): SubTypeSubValue5 {
@@ -378,7 +386,6 @@ export class SubTypeSubValue6
   implements ISubTypeSubValue6, Webpb.WebpbMessage
 {
   value!: number;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "SubTypeSubValue6";
   static CONTEXT = "";
@@ -388,13 +395,15 @@ export class SubTypeSubValue6
   protected constructor(p?: ISubTypeSubValue6) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "SubTypeSubValue6",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: SubTypeSubValue6.CLASS,
+      context: SubTypeSubValue6.CONTEXT,
+      method: SubTypeSubValue6.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ISubTypeSubValue6): SubTypeSubValue6 {

--- a/plugin/testdata/ts/proto3_alias_skip/AliasSkipProto.ts
+++ b/plugin/testdata/ts/proto3_alias_skip/AliasSkipProto.ts
@@ -12,7 +12,6 @@ export interface IAliasSkip {
 export class AliasSkip implements IAliasSkip, Webpb.WebpbMessage {
   b?: number | null;
   a?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "AliasSkip";
   static CONTEXT = "";
@@ -21,13 +20,15 @@ export class AliasSkip implements IAliasSkip, Webpb.WebpbMessage {
 
   protected constructor(p?: IAliasSkip) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "AliasSkip",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: AliasSkip.CLASS,
+      context: AliasSkip.CONTEXT,
+      method: AliasSkip.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IAliasSkip): AliasSkip {

--- a/plugin/testdata/ts/proto3_auto_alias/AliasReserveProto.ts
+++ b/plugin/testdata/ts/proto3_auto_alias/AliasReserveProto.ts
@@ -13,7 +13,6 @@ export class AliasReserveParent
   implements IAliasReserveParent, Webpb.WebpbMessage
 {
   foo_1?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "AliasReserveParent";
   static CONTEXT = "";
@@ -22,13 +21,15 @@ export class AliasReserveParent
 
   protected constructor(p?: IAliasReserveParent) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "AliasReserveParent",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: AliasReserveParent.CLASS,
+      context: AliasReserveParent.CONTEXT,
+      method: AliasReserveParent.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IAliasReserveParent): AliasReserveParent {
@@ -59,7 +60,6 @@ export class AliasReserveChild
   implements IAliasReserveChild, Webpb.WebpbMessage
 {
   foo_2?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "AliasReserveChild";
   static CONTEXT = "";
@@ -69,13 +69,15 @@ export class AliasReserveChild
   protected constructor(p?: IAliasReserveChild) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "AliasReserveChild",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: AliasReserveChild.CLASS,
+      context: AliasReserveChild.CONTEXT,
+      method: AliasReserveChild.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IAliasReserveChild): AliasReserveChild {

--- a/plugin/testdata/ts/proto3_auto_alias/ExtendsProto.ts
+++ b/plugin/testdata/ts/proto3_auto_alias/ExtendsProto.ts
@@ -11,7 +11,6 @@ export interface ILevel3 {
 
 export class Level3 implements ILevel3, Webpb.WebpbMessage {
   foo_1?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level3";
   static CONTEXT = "";
@@ -20,13 +19,15 @@ export class Level3 implements ILevel3, Webpb.WebpbMessage {
 
   protected constructor(p?: ILevel3) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Level3",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level3.CLASS,
+      context: Level3.CONTEXT,
+      method: Level3.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel3): Level3 {
@@ -56,7 +57,6 @@ export class Level2
   implements ILevel2, Webpb.WebpbMessage
 {
   foo_2?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level2";
   static CONTEXT = "";
@@ -66,13 +66,15 @@ export class Level2
   protected constructor(p?: ILevel2) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Level2",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level2.CLASS,
+      context: Level2.CONTEXT,
+      method: Level2.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel2): Level2 {
@@ -106,7 +108,6 @@ export class Level1
 {
   foo_3?: number | null;
   foo_4?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level1";
   static CONTEXT = "";
@@ -116,13 +117,15 @@ export class Level1
   protected constructor(p?: ILevel1) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Level1",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level1.CLASS,
+      context: Level1.CONTEXT,
+      method: Level1.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel1): Level1 {

--- a/plugin/testdata/ts/proto3_auto_alias/FieldOptsProto.ts
+++ b/plugin/testdata/ts/proto3_auto_alias/FieldOptsProto.ts
@@ -10,7 +10,6 @@ export interface ILevel3 {
 
 export class Level3 implements ILevel3, Webpb.WebpbMessage {
   test1?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level3";
   static CONTEXT = "";
@@ -19,13 +18,15 @@ export class Level3 implements ILevel3, Webpb.WebpbMessage {
 
   protected constructor(p?: ILevel3) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Level3",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level3.CLASS,
+      context: Level3.CONTEXT,
+      method: Level3.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel3): Level3 {
@@ -51,7 +52,6 @@ export class Level2 implements ILevel2, Webpb.WebpbMessage {
   test1?: number | null;
   test2?: ILevel3 | null;
   test3!: ILevel3[];
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level2";
   static CONTEXT = "";
@@ -62,13 +62,15 @@ export class Level2 implements ILevel2, Webpb.WebpbMessage {
     Webpb.assign(p, this, []);
     p?.test2 && (this.test2 = Level3.create(p.test2));
     p?.test3 && (this.test3 = p.test3.map((x) => Level3.create(x)));
-    this.webpbMeta = () =>
-      ({
-        class: "Level2",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level2.CLASS,
+      context: Level2.CONTEXT,
+      method: Level2.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel2): Level2 {
@@ -112,7 +114,6 @@ export class Level1 implements ILevel1, Webpb.WebpbMessage {
   test4?: ILevel3 | null;
   test5!: Record<number, ILevel3>;
   test6!: Record<string, ILevel3>;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level1";
   static CONTEXT = "";
@@ -128,13 +129,15 @@ export class Level1 implements ILevel1, Webpb.WebpbMessage {
       (this.test5 = Webpb.mapValues(p.test5, (x) => Level3.create(x)));
     p?.test6 &&
       (this.test6 = Webpb.mapValues(p.test6, (x) => Level3.create(x)));
-    this.webpbMeta = () =>
-      ({
-        class: "Level1",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level1.CLASS,
+      context: Level1.CONTEXT,
+      method: Level1.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel1): Level1 {

--- a/plugin/testdata/ts/proto3_auto_alias/FileOptsProto.ts
+++ b/plugin/testdata/ts/proto3_auto_alias/FileOptsProto.ts
@@ -10,7 +10,6 @@ export interface ILevel3 {
 
 export class Level3 implements ILevel3, Webpb.WebpbMessage {
   test1?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level3";
   static CONTEXT = "";
@@ -19,13 +18,15 @@ export class Level3 implements ILevel3, Webpb.WebpbMessage {
 
   protected constructor(p?: ILevel3) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Level3",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level3.CLASS,
+      context: Level3.CONTEXT,
+      method: Level3.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel3): Level3 {
@@ -56,7 +57,6 @@ export class Level2 implements ILevel2, Webpb.WebpbMessage {
   test1?: number | null;
   test2?: ILevel3 | null;
   test3!: ILevel3[];
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level2";
   static CONTEXT = "";
@@ -67,13 +67,15 @@ export class Level2 implements ILevel2, Webpb.WebpbMessage {
     Webpb.assign(p, this, []);
     p?.test2 && (this.test2 = Level3.create(p.test2));
     p?.test3 && (this.test3 = p.test3.map((x) => Level3.create(x)));
-    this.webpbMeta = () =>
-      ({
-        class: "Level2",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level2.CLASS,
+      context: Level2.CONTEXT,
+      method: Level2.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel2): Level2 {
@@ -122,7 +124,6 @@ export class Level1 implements ILevel1, Webpb.WebpbMessage {
   test4?: ILevel3 | null;
   test5!: Record<number, ILevel3>;
   test6!: Record<string, ILevel3>;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level1";
   static CONTEXT = "";
@@ -138,13 +139,15 @@ export class Level1 implements ILevel1, Webpb.WebpbMessage {
       (this.test5 = Webpb.mapValues(p.test5, (x) => Level3.create(x)));
     p?.test6 &&
       (this.test6 = Webpb.mapValues(p.test6, (x) => Level3.create(x)));
-    this.webpbMeta = () =>
-      ({
-        class: "Level1",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level1.CLASS,
+      context: Level1.CONTEXT,
+      method: Level1.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel1): Level1 {

--- a/plugin/testdata/ts/proto3_auto_alias/MessageOptsProto.ts
+++ b/plugin/testdata/ts/proto3_auto_alias/MessageOptsProto.ts
@@ -10,7 +10,6 @@ export interface ILevel3 {
 
 export class Level3 implements ILevel3, Webpb.WebpbMessage {
   test1?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level3";
   static CONTEXT = "";
@@ -19,13 +18,15 @@ export class Level3 implements ILevel3, Webpb.WebpbMessage {
 
   protected constructor(p?: ILevel3) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Level3",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level3.CLASS,
+      context: Level3.CONTEXT,
+      method: Level3.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel3): Level3 {
@@ -56,7 +57,6 @@ export class Level2 implements ILevel2, Webpb.WebpbMessage {
   test1?: number | null;
   test2?: ILevel3 | null;
   test3!: ILevel3[];
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level2";
   static CONTEXT = "";
@@ -67,13 +67,15 @@ export class Level2 implements ILevel2, Webpb.WebpbMessage {
     Webpb.assign(p, this, []);
     p?.test2 && (this.test2 = Level3.create(p.test2));
     p?.test3 && (this.test3 = p.test3.map((x) => Level3.create(x)));
-    this.webpbMeta = () =>
-      ({
-        class: "Level2",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level2.CLASS,
+      context: Level2.CONTEXT,
+      method: Level2.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel2): Level2 {
@@ -111,7 +113,6 @@ export class Level1 implements ILevel1, Webpb.WebpbMessage {
   test4?: ILevel3 | null;
   test5!: Record<number, ILevel3>;
   test6!: Record<string, ILevel3>;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level1";
   static CONTEXT = "";
@@ -127,13 +128,15 @@ export class Level1 implements ILevel1, Webpb.WebpbMessage {
       (this.test5 = Webpb.mapValues(p.test5, (x) => Level3.create(x)));
     p?.test6 &&
       (this.test6 = Webpb.mapValues(p.test6, (x) => Level3.create(x)));
-    this.webpbMeta = () =>
-      ({
-        class: "Level1",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level1.CLASS,
+      context: Level1.CONTEXT,
+      method: Level1.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel1): Level1 {

--- a/plugin/testdata/ts/proto3_auto_alias/WebpbOptsProto.ts
+++ b/plugin/testdata/ts/proto3_auto_alias/WebpbOptsProto.ts
@@ -10,7 +10,6 @@ export interface ILevel3 {
 
 export class Level3 implements ILevel3, Webpb.WebpbMessage {
   test1?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level3";
   static CONTEXT = "";
@@ -19,13 +18,15 @@ export class Level3 implements ILevel3, Webpb.WebpbMessage {
 
   protected constructor(p?: ILevel3) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Level3",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level3.CLASS,
+      context: Level3.CONTEXT,
+      method: Level3.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel3): Level3 {
@@ -56,7 +57,6 @@ export class Level2 implements ILevel2, Webpb.WebpbMessage {
   test1?: number | null;
   test2?: ILevel3 | null;
   test3!: ILevel3[];
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level2";
   static CONTEXT = "";
@@ -67,13 +67,15 @@ export class Level2 implements ILevel2, Webpb.WebpbMessage {
     Webpb.assign(p, this, []);
     p?.test2 && (this.test2 = Level3.create(p.test2));
     p?.test3 && (this.test3 = p.test3.map((x) => Level3.create(x)));
-    this.webpbMeta = () =>
-      ({
-        class: "Level2",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level2.CLASS,
+      context: Level2.CONTEXT,
+      method: Level2.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel2): Level2 {
@@ -122,7 +124,6 @@ export class Level1 implements ILevel1, Webpb.WebpbMessage {
   test4?: ILevel3 | null;
   test5!: Record<number, ILevel3>;
   test6!: Record<string, ILevel3>;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Level1";
   static CONTEXT = "";
@@ -138,13 +139,15 @@ export class Level1 implements ILevel1, Webpb.WebpbMessage {
       (this.test5 = Webpb.mapValues(p.test5, (x) => Level3.create(x)));
     p?.test6 &&
       (this.test6 = Webpb.mapValues(p.test6, (x) => Level3.create(x)));
-    this.webpbMeta = () =>
-      ({
-        class: "Level1",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Level1.CLASS,
+      context: Level1.CONTEXT,
+      method: Level1.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ILevel1): Level1 {

--- a/plugin/testdata/ts/proto3_core_codegen/IgnoredProto.ts
+++ b/plugin/testdata/ts/proto3_core_codegen/IgnoredProto.ts
@@ -10,7 +10,6 @@ export interface IIgnoreTest {
 
 export class IgnoreTest implements IIgnoreTest, Webpb.WebpbMessage {
   test1?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "IgnoreTest";
   static CONTEXT = "";
@@ -19,13 +18,15 @@ export class IgnoreTest implements IIgnoreTest, Webpb.WebpbMessage {
 
   protected constructor(p?: IIgnoreTest) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "IgnoreTest",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: IgnoreTest.CLASS,
+      context: IgnoreTest.CONTEXT,
+      method: IgnoreTest.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IIgnoreTest): IgnoreTest {

--- a/plugin/testdata/ts/proto3_core_codegen/Include2Proto.ts
+++ b/plugin/testdata/ts/proto3_core_codegen/Include2Proto.ts
@@ -10,7 +10,6 @@ export interface IMessage {
 
 export class Message implements IMessage, Webpb.WebpbMessage {
   id?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Message";
   static CONTEXT = "";
@@ -19,13 +18,15 @@ export class Message implements IMessage, Webpb.WebpbMessage {
 
   protected constructor(p?: IMessage) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Message",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Message.CLASS,
+      context: Message.CONTEXT,
+      method: Message.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IMessage): Message {
@@ -48,7 +49,6 @@ export namespace Message {
 
   export class Nested implements INested, Webpb.WebpbMessage {
     test1?: number | null;
-    webpbMeta: () => Webpb.WebpbMeta;
 
     static CLASS = "Nested";
     static CONTEXT = "";
@@ -57,13 +57,15 @@ export namespace Message {
 
     protected constructor(p?: INested) {
       Webpb.assign(p, this, []);
-      this.webpbMeta = () =>
-        ({
-          class: "Nested",
-          context: "",
-          method: "",
-          path: "",
-        }) as Webpb.WebpbMeta;
+    }
+
+    webpbMeta(): Webpb.WebpbMeta {
+      return {
+        class: Nested.CLASS,
+        context: Nested.CONTEXT,
+        method: Nested.METHOD,
+        path: "",
+      };
     }
 
     static create(p?: INested): Nested {

--- a/plugin/testdata/ts/proto3_core_codegen/IncludeProto.ts
+++ b/plugin/testdata/ts/proto3_core_codegen/IncludeProto.ts
@@ -22,7 +22,6 @@ export interface IMessage {
 
 export class Message implements IMessage, Webpb.WebpbMessage {
   id?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Message";
   static CONTEXT = "";
@@ -31,13 +30,15 @@ export class Message implements IMessage, Webpb.WebpbMessage {
 
   protected constructor(p?: IMessage) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Message",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Message.CLASS,
+      context: Message.CONTEXT,
+      method: Message.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IMessage): Message {
@@ -60,7 +61,6 @@ export namespace Message {
 
   export class Nested implements INested, Webpb.WebpbMessage {
     test1?: number | null;
-    webpbMeta: () => Webpb.WebpbMeta;
 
     static CLASS = "Nested";
     static CONTEXT = "";
@@ -69,13 +69,15 @@ export namespace Message {
 
     protected constructor(p?: INested) {
       Webpb.assign(p, this, []);
-      this.webpbMeta = () =>
-        ({
-          class: "Nested",
-          context: "",
-          method: "",
-          path: "",
-        }) as Webpb.WebpbMeta;
+    }
+
+    webpbMeta(): Webpb.WebpbMeta {
+      return {
+        class: Nested.CLASS,
+        context: Nested.CONTEXT,
+        method: Nested.METHOD,
+        path: "",
+      };
     }
 
     static create(p?: INested): Nested {

--- a/plugin/testdata/ts/proto3_core_codegen/TestProto.ts
+++ b/plugin/testdata/ts/proto3_core_codegen/TestProto.ts
@@ -54,7 +54,6 @@ export interface ITest1 {
 export class Test1 implements ITest1, Webpb.WebpbMessage {
   test1?: string | null;
   test2?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Test1";
   static CONTEXT = "/test";
@@ -63,19 +62,21 @@ export class Test1 implements ITest1, Webpb.WebpbMessage {
 
   protected constructor(p?: ITest1) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Test1",
-        context: "/test",
-        method: "GET",
-        path: `/test${Webpb.query("?", {
-          a: "123",
-          b: p?.test1,
-          c: "321",
-          d: p?.test2,
-          e: "456",
-        })}`,
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Test1.CLASS,
+      context: Test1.CONTEXT,
+      method: Test1.METHOD,
+      path: `/test${Webpb.query("?", {
+        a: "123",
+        b: this.test1,
+        c: "321",
+        d: this.test2,
+        e: "456",
+      })}`,
+    };
   }
 
   static create(p?: ITest1): Test1 {
@@ -103,7 +104,6 @@ export class Test2 extends AbstractClass implements ITest2, Webpb.WebpbMessage {
   test2?: string | null;
   test3?: ITest6 | null;
   test4!: Record<number, ITest1>;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Test2";
   static CONTEXT = "/test";
@@ -116,17 +116,19 @@ export class Test2 extends AbstractClass implements ITest2, Webpb.WebpbMessage {
     Webpb.assign(p, this, []);
     p?.test3 && (this.test3 = Test6.create(p.test3));
     p?.test4 && (this.test4 = Webpb.mapValues(p.test4, (x) => Test1.create(x)));
-    this.webpbMeta = () =>
-      ({
-        class: "Test2",
-        context: "/test",
-        method: "GET",
-        path: `/test/${p?.test2}${Webpb.query("?", {
-          data1: Webpb.getter(p, "test3.test1"),
-          data2: Webpb.getter(p, "test3.test2"),
-          id: p?.test1,
-        })}`,
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Test2.CLASS,
+      context: Test2.CONTEXT,
+      method: Test2.METHOD,
+      path: `/test/${this.test2}${Webpb.query("?", {
+        data1: Webpb.getter(this, "test3.test1"),
+        data2: Webpb.getter(this, "test3.test2"),
+        id: this.test1,
+      })}`,
+    };
   }
 
   static create(p?: ITest2): Test2 {
@@ -157,7 +159,6 @@ export class Test4 implements ITest4, Webpb.WebpbMessage {
   test2?: number | null;
   test3?: string | null;
   test4!: string[];
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Test4";
   static CONTEXT = "";
@@ -166,13 +167,15 @@ export class Test4 implements ITest4, Webpb.WebpbMessage {
 
   protected constructor(p?: ITest4) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Test4",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Test4.CLASS,
+      context: Test4.CONTEXT,
+      method: Test4.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ITest4): Test4 {
@@ -203,7 +206,6 @@ export interface ITest6 {
 export class Test6 implements ITest6, Webpb.WebpbMessage {
   test1?: string | null;
   test2?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Test6";
   static CONTEXT = "";
@@ -212,13 +214,15 @@ export class Test6 implements ITest6, Webpb.WebpbMessage {
 
   protected constructor(p?: ITest6) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Test6",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Test6.CLASS,
+      context: Test6.CONTEXT,
+      method: Test6.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ITest6): Test6 {
@@ -276,7 +280,6 @@ export class Test implements ITest, Webpb.WebpbMessage {
   test17?: Test.ITest17 | null;
   test18?: number | null;
   test19?: string | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Test";
   static CONTEXT = "/test";
@@ -299,13 +302,15 @@ export class Test implements ITest, Webpb.WebpbMessage {
       (this.test13 = p.test13.map((x) => Include2Proto.Message.create(x)));
     p?.test14 && (this.test14 = Include2Proto.Message.Nested.create(p.test14));
     p?.test17 && (this.test17 = Test.Test17.create(p.test17));
-    this.webpbMeta = () =>
-      ({
-        class: "Test",
-        context: "/test",
-        method: "GET",
-        path: `/test/${p?.test1}`,
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Test.CLASS,
+      context: Test.CONTEXT,
+      method: Test.METHOD,
+      path: `/test/${this.test1}`,
+    };
   }
 
   static create(p?: ITest): Test {
@@ -347,7 +352,6 @@ export namespace Test {
 
   export class NestedTest implements INestedTest, Webpb.WebpbMessage {
     test1?: number | null;
-    webpbMeta: () => Webpb.WebpbMeta;
 
     static CLASS = "NestedTest";
     static CONTEXT = "/test";
@@ -356,13 +360,15 @@ export namespace Test {
 
     protected constructor(p?: INestedTest) {
       Webpb.assign(p, this, []);
-      this.webpbMeta = () =>
-        ({
-          class: "NestedTest",
-          context: "/test",
-          method: "GET",
-          path: `/test/nested/${p?.test1}`,
-        }) as Webpb.WebpbMeta;
+    }
+
+    webpbMeta(): Webpb.WebpbMeta {
+      return {
+        class: NestedTest.CLASS,
+        context: NestedTest.CONTEXT,
+        method: NestedTest.METHOD,
+        path: `/test/nested/${this.test1}`,
+      };
     }
 
     static create(p?: INestedTest): NestedTest {
@@ -384,7 +390,6 @@ export namespace Test {
 
   export class Test17 implements ITest17, Webpb.WebpbMessage {
     test?: string | null;
-    webpbMeta: () => Webpb.WebpbMeta;
 
     static CLASS = "Test17";
     static CONTEXT = "";
@@ -393,13 +398,15 @@ export namespace Test {
 
     protected constructor(p?: ITest17) {
       Webpb.assign(p, this, []);
-      this.webpbMeta = () =>
-        ({
-          class: "Test17",
-          context: "",
-          method: "",
-          path: "",
-        }) as Webpb.WebpbMeta;
+    }
+
+    webpbMeta(): Webpb.WebpbMeta {
+      return {
+        class: Test17.CLASS,
+        context: Test17.CONTEXT,
+        method: Test17.METHOD,
+        path: "",
+      };
     }
 
     static create(p?: ITest17): Test17 {

--- a/plugin/testdata/ts/proto3_enumeration/MapValueTestProto.ts
+++ b/plugin/testdata/ts/proto3_enumeration/MapValueTestProto.ts
@@ -24,7 +24,6 @@ export interface IMapValueTestPb {
 
 export class MapValueTestPb implements IMapValueTestPb, Webpb.WebpbMessage {
   sort!: Record<string, Direction>;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "MapValueTestPb";
   static CONTEXT = "";
@@ -33,13 +32,15 @@ export class MapValueTestPb implements IMapValueTestPb, Webpb.WebpbMessage {
 
   protected constructor(p?: IMapValueTestPb) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "MapValueTestPb",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: MapValueTestPb.CLASS,
+      context: MapValueTestPb.CONTEXT,
+      method: MapValueTestPb.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IMapValueTestPb): MapValueTestPb {

--- a/plugin/testdata/ts/proto3_errors/BadAnnotationProto.ts
+++ b/plugin/testdata/ts/proto3_errors/BadAnnotationProto.ts
@@ -12,7 +12,6 @@ export interface IBadAnnotation {
 export class BadAnnotation implements IBadAnnotation, Webpb.WebpbMessage {
   foo_2?: number | null;
   bar_2?: string | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "BadAnnotation";
   static CONTEXT = "";
@@ -21,13 +20,15 @@ export class BadAnnotation implements IBadAnnotation, Webpb.WebpbMessage {
 
   protected constructor(p?: IBadAnnotation) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "BadAnnotation",
-        context: "",
-        method: "",
-        path: "",
-      } as Webpb.WebpbMeta);
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: BadAnnotation.CLASS,
+      context: BadAnnotation.CONTEXT,
+      method: BadAnnotation.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IBadAnnotation): BadAnnotation {

--- a/plugin/testdata/ts/proto3_errors/BadClassOrInterfaceProto.ts
+++ b/plugin/testdata/ts/proto3_errors/BadClassOrInterfaceProto.ts
@@ -12,7 +12,6 @@ export interface IBadAnnotation extends ....IBadClassOrInterface {
 export class BadAnnotation extends ....BadClassOrInterface implements IBadAnnotation, Webpb.WebpbMessage {
   foo_2?: number | null;
   bar_2?: string | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "BadAnnotation";
   static CONTEXT = "";
@@ -22,13 +21,15 @@ export class BadAnnotation extends ....BadClassOrInterface implements IBadAnnota
   protected constructor(p?: IBadAnnotation) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "BadAnnotation",
-        context: "",
-        method: "",
-        path: "",
-      } as Webpb.WebpbMeta);
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: BadAnnotation.CLASS,
+      context: BadAnnotation.CONTEXT,
+      method: BadAnnotation.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IBadAnnotation): BadAnnotation {

--- a/plugin/testdata/ts/proto3_errors/BadExtendsProto.ts
+++ b/plugin/testdata/ts/proto3_errors/BadExtendsProto.ts
@@ -10,7 +10,6 @@ export interface IBadExtends extends IBadExtendsFoo<"foo"> {
 
 export class BadExtends extends BadExtendsFoo<"foo"> implements IBadExtends, Webpb.WebpbMessage {
   value?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "BadExtends";
   static CONTEXT = "";
@@ -20,13 +19,15 @@ export class BadExtends extends BadExtendsFoo<"foo"> implements IBadExtends, Web
   protected constructor(p?: IBadExtends) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "BadExtends",
-        context: "",
-        method: "",
-        path: "",
-      } as Webpb.WebpbMeta);
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: BadExtends.CLASS,
+      context: BadExtends.CONTEXT,
+      method: BadExtends.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IBadExtends): BadExtends {

--- a/plugin/testdata/ts/proto3_errors/ImportPathNotFoundProto.ts
+++ b/plugin/testdata/ts/proto3_errors/ImportPathNotFoundProto.ts
@@ -13,7 +13,6 @@ export interface IImportPathNotFound extends BadImport.IExtends {
 export class ImportPathNotFound extends BadImport.Extends implements IImportPathNotFound, Webpb.WebpbMessage {
   foo_2?: number | null;
   bar_2?: string | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "ImportPathNotFound";
   static CONTEXT = "";
@@ -23,13 +22,15 @@ export class ImportPathNotFound extends BadImport.Extends implements IImportPath
   protected constructor(p?: IImportPathNotFound) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "ImportPathNotFound",
-        context: "",
-        method: "",
-        path: "",
-      } as Webpb.WebpbMeta);
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: ImportPathNotFound.CLASS,
+      context: ImportPathNotFound.CONTEXT,
+      method: ImportPathNotFound.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IImportPathNotFound): ImportPathNotFound {

--- a/plugin/testdata/ts/proto3_errors/TestProto.ts
+++ b/plugin/testdata/ts/proto3_errors/TestProto.ts
@@ -10,7 +10,6 @@ export interface ITest {
 
 export class Test implements ITest, Webpb.WebpbMessage {
   test1?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Test";
   static CONTEXT = "";
@@ -19,13 +18,15 @@ export class Test implements ITest, Webpb.WebpbMessage {
 
   protected constructor(p?: ITest) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Test",
-        context: "",
-        method: "",
-        path: "",
-      } as Webpb.WebpbMeta);
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Test.CLASS,
+      context: Test.CONTEXT,
+      method: Test.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ITest): Test {

--- a/plugin/testdata/ts/proto3_generator_options/HttpMethodsProto.ts
+++ b/plugin/testdata/ts/proto3_generator_options/HttpMethodsProto.ts
@@ -12,7 +12,6 @@ export interface IPostRequest {
 export class PostRequest implements IPostRequest, Webpb.WebpbMessage {
   id?: number | null;
   body?: string | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "PostRequest";
   static CONTEXT = "/api";
@@ -21,13 +20,15 @@ export class PostRequest implements IPostRequest, Webpb.WebpbMessage {
 
   protected constructor(p?: IPostRequest) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "PostRequest",
-        context: "/api",
-        method: "POST",
-        path: `/items/${p?.id}`,
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: PostRequest.CLASS,
+      context: PostRequest.CONTEXT,
+      method: PostRequest.METHOD,
+      path: `/items/${this.id}`,
+    };
   }
 
   static create(p?: IPostRequest): PostRequest {
@@ -51,7 +52,6 @@ export interface IPutRequest {
 export class PutRequest implements IPutRequest, Webpb.WebpbMessage {
   id?: number | null;
   body?: string | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "PutRequest";
   static CONTEXT = "/api";
@@ -60,13 +60,15 @@ export class PutRequest implements IPutRequest, Webpb.WebpbMessage {
 
   protected constructor(p?: IPutRequest) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "PutRequest",
-        context: "/api",
-        method: "PUT",
-        path: `/items/${p?.id}`,
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: PutRequest.CLASS,
+      context: PutRequest.CONTEXT,
+      method: PutRequest.METHOD,
+      path: `/items/${this.id}`,
+    };
   }
 
   static create(p?: IPutRequest): PutRequest {
@@ -88,7 +90,6 @@ export interface IDeleteRequest {
 
 export class DeleteRequest implements IDeleteRequest, Webpb.WebpbMessage {
   id?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "DeleteRequest";
   static CONTEXT = "/api";
@@ -97,13 +98,15 @@ export class DeleteRequest implements IDeleteRequest, Webpb.WebpbMessage {
 
   protected constructor(p?: IDeleteRequest) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "DeleteRequest",
-        context: "/api",
-        method: "DELETE",
-        path: `/items/${p?.id}`,
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: DeleteRequest.CLASS,
+      context: DeleteRequest.CONTEXT,
+      method: DeleteRequest.METHOD,
+      path: `/items/${this.id}`,
+    };
   }
 
   static create(p?: IDeleteRequest): DeleteRequest {

--- a/plugin/testdata/ts/proto3_generator_options/PrimitiveTypesProto.ts
+++ b/plugin/testdata/ts/proto3_generator_options/PrimitiveTypesProto.ts
@@ -30,7 +30,6 @@ export class PrimitiveTypes implements IPrimitiveTypes, Webpb.WebpbMessage {
   sfixed32_field?: number | null;
   sfixed64_field?: number | null;
   repeated_float!: number[];
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "PrimitiveTypes";
   static CONTEXT = "";
@@ -39,13 +38,15 @@ export class PrimitiveTypes implements IPrimitiveTypes, Webpb.WebpbMessage {
 
   protected constructor(p?: IPrimitiveTypes) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "PrimitiveTypes",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: PrimitiveTypes.CLASS,
+      context: PrimitiveTypes.CONTEXT,
+      method: PrimitiveTypes.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IPrimitiveTypes): PrimitiveTypes {

--- a/plugin/testdata/ts/proto3_generator_options/RepeatedEnumProto.ts
+++ b/plugin/testdata/ts/proto3_generator_options/RepeatedEnumProto.ts
@@ -26,7 +26,6 @@ export interface IRepeatedEnum {
 export class RepeatedEnum implements IRepeatedEnum, Webpb.WebpbMessage {
   status!: Status[];
   status_by_code!: Record<number, Status>;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "RepeatedEnum";
   static CONTEXT = "";
@@ -35,13 +34,15 @@ export class RepeatedEnum implements IRepeatedEnum, Webpb.WebpbMessage {
 
   protected constructor(p?: IRepeatedEnum) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "RepeatedEnum",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: RepeatedEnum.CLASS,
+      context: RepeatedEnum.CONTEXT,
+      method: RepeatedEnum.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IRepeatedEnum): RepeatedEnum {
@@ -68,7 +69,6 @@ export namespace RepeatedEnum {
   {
     key?: number | null;
     value?: Status | null;
-    webpbMeta: () => Webpb.WebpbMeta;
 
     static CLASS = "StatusByCodeEntry";
     static CONTEXT = "";
@@ -77,13 +77,15 @@ export namespace RepeatedEnum {
 
     protected constructor(p?: IStatusByCodeEntry) {
       Webpb.assign(p, this, []);
-      this.webpbMeta = () =>
-        ({
-          class: "StatusByCodeEntry",
-          context: "",
-          method: "",
-          path: "",
-        }) as Webpb.WebpbMeta;
+    }
+
+    webpbMeta(): Webpb.WebpbMeta {
+      return {
+        class: StatusByCodeEntry.CLASS,
+        context: StatusByCodeEntry.CONTEXT,
+        method: StatusByCodeEntry.METHOD,
+        path: "",
+      };
     }
 
     static create(p?: IStatusByCodeEntry): StatusByCodeEntry {

--- a/plugin/testdata/ts/proto3_generator_options/RepeatedFieldTypesProto.ts
+++ b/plugin/testdata/ts/proto3_generator_options/RepeatedFieldTypesProto.ts
@@ -16,7 +16,6 @@ export class RepeatedFieldTypes
   as_list!: string[];
   as_set!: string[];
   as_collection!: string[];
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "RepeatedFieldTypes";
   static CONTEXT = "";
@@ -25,13 +24,15 @@ export class RepeatedFieldTypes
 
   protected constructor(p?: IRepeatedFieldTypes) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "RepeatedFieldTypes",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: RepeatedFieldTypes.CLASS,
+      context: RepeatedFieldTypes.CONTEXT,
+      method: RepeatedFieldTypes.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IRepeatedFieldTypes): RepeatedFieldTypes {

--- a/plugin/testdata/ts/proto3_generator_options/Test10Proto.ts
+++ b/plugin/testdata/ts/proto3_generator_options/Test10Proto.ts
@@ -10,7 +10,6 @@ export interface ITest10 {
 
 export class Test10 implements ITest10, Webpb.WebpbMessage {
   test1?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Test10";
   static CONTEXT = "";
@@ -19,13 +18,15 @@ export class Test10 implements ITest10, Webpb.WebpbMessage {
 
   protected constructor(p?: ITest10) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Test10",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Test10.CLASS,
+      context: Test10.CONTEXT,
+      method: Test10.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ITest10): Test10 {

--- a/plugin/testdata/ts/proto3_generator_options/Test11Proto.ts
+++ b/plugin/testdata/ts/proto3_generator_options/Test11Proto.ts
@@ -12,7 +12,6 @@ export interface ITest11 {
 export class Test11 implements ITest11, Webpb.WebpbMessage {
   test1?: number | null;
   test11?: ITest11 | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Test11";
   static CONTEXT = "";
@@ -22,13 +21,15 @@ export class Test11 implements ITest11, Webpb.WebpbMessage {
   protected constructor(p?: ITest11) {
     Webpb.assign(p, this, []);
     p?.test11 && (this.test11 = Test11.create(p.test11));
-    this.webpbMeta = () =>
-      ({
-        class: "Test11",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Test11.CLASS,
+      context: Test11.CONTEXT,
+      method: Test11.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ITest11): Test11 {

--- a/plugin/testdata/ts/proto3_generator_options/Test1Proto.ts
+++ b/plugin/testdata/ts/proto3_generator_options/Test1Proto.ts
@@ -7,8 +7,6 @@ import * as Webpb from "webpb";
 export interface ITest {}
 
 export class Test implements ITest, Webpb.WebpbMessage {
-  webpbMeta: () => Webpb.WebpbMeta;
-
   static CLASS = "Test";
   static CONTEXT = "";
   static METHOD = "";
@@ -16,13 +14,15 @@ export class Test implements ITest, Webpb.WebpbMessage {
 
   protected constructor(p?: ITest) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Test",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Test.CLASS,
+      context: Test.CONTEXT,
+      method: Test.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ITest): Test {

--- a/plugin/testdata/ts/proto3_generator_options/Test2Proto.ts
+++ b/plugin/testdata/ts/proto3_generator_options/Test2Proto.ts
@@ -14,7 +14,6 @@ export class Test implements ITest, Webpb.WebpbMessage {
   test1?: number | null;
   test2?: boolean | null;
   isTest3?: boolean | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Test";
   static CONTEXT = "";
@@ -23,13 +22,15 @@ export class Test implements ITest, Webpb.WebpbMessage {
 
   protected constructor(p?: ITest) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Test",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Test.CLASS,
+      context: Test.CONTEXT,
+      method: Test.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ITest): Test {

--- a/plugin/testdata/ts/proto3_generator_options/Test3Proto.ts
+++ b/plugin/testdata/ts/proto3_generator_options/Test3Proto.ts
@@ -10,7 +10,6 @@ export interface ITest {
 
 export class Test implements ITest, Webpb.WebpbMessage {
   test1?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Test";
   static CONTEXT = "";
@@ -19,13 +18,15 @@ export class Test implements ITest, Webpb.WebpbMessage {
 
   protected constructor(p?: ITest) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Test",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Test.CLASS,
+      context: Test.CONTEXT,
+      method: Test.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ITest): Test {

--- a/plugin/testdata/ts/proto3_generator_options/Test4Proto.ts
+++ b/plugin/testdata/ts/proto3_generator_options/Test4Proto.ts
@@ -10,7 +10,6 @@ export interface ITest {
 
 export class Test implements ITest, Webpb.WebpbMessage {
   test1?: string | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Test";
   static CONTEXT = "";
@@ -19,13 +18,15 @@ export class Test implements ITest, Webpb.WebpbMessage {
 
   protected constructor(p?: ITest) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Test",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Test.CLASS,
+      context: Test.CONTEXT,
+      method: Test.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ITest): Test {

--- a/plugin/testdata/ts/proto3_generator_options/Test9Proto.ts
+++ b/plugin/testdata/ts/proto3_generator_options/Test9Proto.ts
@@ -10,7 +10,6 @@ export interface ITest9 {
 
 export class Test9 implements ITest9, Webpb.WebpbMessage {
   test1?: string | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Test9";
   static CONTEXT = "";
@@ -19,13 +18,15 @@ export class Test9 implements ITest9, Webpb.WebpbMessage {
 
   protected constructor(p?: ITest9) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Test9",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Test9.CLASS,
+      context: Test9.CONTEXT,
+      method: Test9.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ITest9): Test9 {

--- a/plugin/testdata/ts/proto3_imports/ImportTestProto.ts
+++ b/plugin/testdata/ts/proto3_imports/ImportTestProto.ts
@@ -18,7 +18,6 @@ export class ImportTest
   foo_2?: number | null;
   bar_2?: string | null;
   no_package?: NoPackageProto.INoPackage | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "ImportTest";
   static CONTEXT = "";
@@ -30,13 +29,15 @@ export class ImportTest
     Webpb.assign(p, this, []);
     p?.no_package &&
       (this.no_package = NoPackageProto.NoPackage.create(p.no_package));
-    this.webpbMeta = () =>
-      ({
-        class: "ImportTest",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: ImportTest.CLASS,
+      context: ImportTest.CONTEXT,
+      method: ImportTest.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IImportTest): ImportTest {

--- a/plugin/testdata/ts/proto3_imports/NoPackageProto.ts
+++ b/plugin/testdata/ts/proto3_imports/NoPackageProto.ts
@@ -10,7 +10,6 @@ export interface INoPackageTest {
 
 export class NoPackageTest implements INoPackageTest, Webpb.WebpbMessage {
   foo?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "NoPackageTest";
   static CONTEXT = "";
@@ -19,13 +18,15 @@ export class NoPackageTest implements INoPackageTest, Webpb.WebpbMessage {
 
   protected constructor(p?: INoPackageTest) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "NoPackageTest",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: NoPackageTest.CLASS,
+      context: NoPackageTest.CONTEXT,
+      method: NoPackageTest.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: INoPackageTest): NoPackageTest {
@@ -51,7 +52,6 @@ export class NoPackage implements INoPackage, Webpb.WebpbMessage {
   foo_1?: number | null;
   bar_1?: string | null;
   test?: INoPackageTest | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "NoPackage";
   static CONTEXT = "";
@@ -61,13 +61,15 @@ export class NoPackage implements INoPackage, Webpb.WebpbMessage {
   protected constructor(p?: INoPackage) {
     Webpb.assign(p, this, []);
     p?.test && (this.test = NoPackageTest.create(p.test));
-    this.webpbMeta = () =>
-      ({
-        class: "NoPackage",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: NoPackage.CLASS,
+      context: NoPackage.CONTEXT,
+      method: NoPackage.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: INoPackage): NoPackage {

--- a/plugin/testdata/ts/proto3_message_extends/Extends2Proto.ts
+++ b/plugin/testdata/ts/proto3_message_extends/Extends2Proto.ts
@@ -12,7 +12,6 @@ export interface IExtends {
 export class Extends implements IExtends, Webpb.WebpbMessage {
   foo_1?: number | null;
   bar_1?: string | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Extends";
   static CONTEXT = "";
@@ -21,13 +20,15 @@ export class Extends implements IExtends, Webpb.WebpbMessage {
 
   protected constructor(p?: IExtends) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Extends",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Extends.CLASS,
+      context: Extends.CONTEXT,
+      method: Extends.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IExtends): Extends {

--- a/plugin/testdata/ts/proto3_message_extends/ExtendsProto.ts
+++ b/plugin/testdata/ts/proto3_message_extends/ExtendsProto.ts
@@ -12,7 +12,6 @@ export interface IExtends {
 export class Extends implements IExtends, Webpb.WebpbMessage {
   foo_1?: number | null;
   bar_1?: string | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Extends";
   static CONTEXT = "";
@@ -21,13 +20,15 @@ export class Extends implements IExtends, Webpb.WebpbMessage {
 
   protected constructor(p?: IExtends) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Extends",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Extends.CLASS,
+      context: Extends.CONTEXT,
+      method: Extends.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IExtends): Extends {

--- a/plugin/testdata/ts/proto3_message_extends/MainProto.ts
+++ b/plugin/testdata/ts/proto3_message_extends/MainProto.ts
@@ -18,7 +18,6 @@ export class Main1
 {
   foo_2?: number | null;
   bar_2?: string | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Main1";
   static CONTEXT = "";
@@ -28,13 +27,15 @@ export class Main1
   protected constructor(p?: IMain1) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Main1",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Main1.CLASS,
+      context: Main1.CONTEXT,
+      method: Main1.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IMain1): Main1 {
@@ -61,7 +62,6 @@ export class Main2
 {
   foo_2?: number | null;
   bar_2?: string | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Main2";
   static CONTEXT = "";
@@ -71,13 +71,15 @@ export class Main2
   protected constructor(p?: IMain2) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Main2",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Main2.CLASS,
+      context: Main2.CONTEXT,
+      method: Main2.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IMain2): Main2 {
@@ -104,7 +106,6 @@ export class Main3
 {
   foo_2?: number | null;
   bar_2?: string | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Main3";
   static CONTEXT = "";
@@ -114,13 +115,15 @@ export class Main3
   protected constructor(p?: IMain3) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Main3",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Main3.CLASS,
+      context: Main3.CONTEXT,
+      method: Main3.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IMain3): Main3 {
@@ -144,7 +147,6 @@ export interface IMain4 extends ICustom {
 export class Main4 extends Custom implements IMain4, Webpb.WebpbMessage {
   foo_2?: number | null;
   bar_2?: string | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "Main4";
   static CONTEXT = "";
@@ -154,13 +156,15 @@ export class Main4 extends Custom implements IMain4, Webpb.WebpbMessage {
   protected constructor(p?: IMain4) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "Main4",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: Main4.CLASS,
+      context: Main4.CONTEXT,
+      method: Main4.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: IMain4): Main4 {

--- a/plugin/testdata/ts/proto3_message_extends/SubTypeSubValueProto.ts
+++ b/plugin/testdata/ts/proto3_message_extends/SubTypeSubValueProto.ts
@@ -40,7 +40,6 @@ export class SubTypeSubValueStringSuper
   implements ISubTypeSubValueStringSuper, Webpb.WebpbMessage
 {
   type?: string | null;
-  webpbMeta: () => Webpb.WebpbMeta;
   static fromAliases: Record<
     string,
     (data?: unknown) => SubTypeSubValueStringSuper
@@ -53,13 +52,15 @@ export class SubTypeSubValueStringSuper
 
   protected constructor(p?: ISubTypeSubValueStringSuper) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "SubTypeSubValueStringSuper",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: SubTypeSubValueStringSuper.CLASS,
+      context: SubTypeSubValueStringSuper.CONTEXT,
+      method: SubTypeSubValueStringSuper.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ISubTypeSubValueStringSuper): SubTypeSubValueStringSuper {
@@ -89,7 +90,6 @@ export class SubTypeSubValueSuper<
   implements ISubTypeSubValueSuper<T>, Webpb.WebpbMessage
 {
   type?: T;
-  webpbMeta: () => Webpb.WebpbMeta;
   static fromAliases: Record<string, (data?: unknown) => SubTypeSubValueSuper> =
     {};
 
@@ -100,13 +100,15 @@ export class SubTypeSubValueSuper<
 
   protected constructor(p?: ISubTypeSubValueSuper) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "SubTypeSubValueSuper",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: SubTypeSubValueSuper.CLASS,
+      context: SubTypeSubValueSuper.CONTEXT,
+      method: SubTypeSubValueSuper.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ISubTypeSubValueSuper): SubTypeSubValueSuper {
@@ -132,7 +134,6 @@ export class SubTypeSubValue0
   implements ISubTypeSubValue0, Webpb.WebpbMessage
 {
   value?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "SubTypeSubValue0";
   static CONTEXT = "";
@@ -142,13 +143,15 @@ export class SubTypeSubValue0
   protected constructor(p?: ISubTypeSubValue0) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "SubTypeSubValue0",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: SubTypeSubValue0.CLASS,
+      context: SubTypeSubValue0.CONTEXT,
+      method: SubTypeSubValue0.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ISubTypeSubValue0): SubTypeSubValue0 {
@@ -173,7 +176,6 @@ export class SubTypeSubValue1
   implements ISubTypeSubValue1, Webpb.WebpbMessage
 {
   value?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "SubTypeSubValue1";
   static CONTEXT = "";
@@ -183,13 +185,15 @@ export class SubTypeSubValue1
   protected constructor(p?: ISubTypeSubValue1) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "SubTypeSubValue1",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: SubTypeSubValue1.CLASS,
+      context: SubTypeSubValue1.CONTEXT,
+      method: SubTypeSubValue1.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ISubTypeSubValue1): SubTypeSubValue1 {
@@ -218,7 +222,6 @@ export class SubTypeSubValue2
   implements ISubTypeSubValue2, Webpb.WebpbMessage
 {
   value?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "SubTypeSubValue2";
   static CONTEXT = "";
@@ -228,13 +231,15 @@ export class SubTypeSubValue2
   protected constructor(p?: ISubTypeSubValue2) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "SubTypeSubValue2",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: SubTypeSubValue2.CLASS,
+      context: SubTypeSubValue2.CONTEXT,
+      method: SubTypeSubValue2.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ISubTypeSubValue2): SubTypeSubValue2 {
@@ -256,7 +261,6 @@ export interface ISubTypeSubValue3 {
 
 export class SubTypeSubValue3 implements ISubTypeSubValue3, Webpb.WebpbMessage {
   value?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "SubTypeSubValue3";
   static CONTEXT = "";
@@ -265,13 +269,15 @@ export class SubTypeSubValue3 implements ISubTypeSubValue3, Webpb.WebpbMessage {
 
   protected constructor(p?: ISubTypeSubValue3) {
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "SubTypeSubValue3",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: SubTypeSubValue3.CLASS,
+      context: SubTypeSubValue3.CONTEXT,
+      method: SubTypeSubValue3.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ISubTypeSubValue3): SubTypeSubValue3 {
@@ -296,7 +302,6 @@ export class SubTypeSubValue4
   implements ISubTypeSubValue4, Webpb.WebpbMessage
 {
   value?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "SubTypeSubValue4";
   static CONTEXT = "";
@@ -306,13 +311,15 @@ export class SubTypeSubValue4
   protected constructor(p?: ISubTypeSubValue4) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "SubTypeSubValue4",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: SubTypeSubValue4.CLASS,
+      context: SubTypeSubValue4.CONTEXT,
+      method: SubTypeSubValue4.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ISubTypeSubValue4): SubTypeSubValue4 {
@@ -337,7 +344,6 @@ export class SubTypeSubValue5
   implements ISubTypeSubValue5, Webpb.WebpbMessage
 {
   value?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "SubTypeSubValue5";
   static CONTEXT = "";
@@ -347,13 +353,15 @@ export class SubTypeSubValue5
   protected constructor(p?: ISubTypeSubValue5) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "SubTypeSubValue5",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: SubTypeSubValue5.CLASS,
+      context: SubTypeSubValue5.CONTEXT,
+      method: SubTypeSubValue5.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ISubTypeSubValue5): SubTypeSubValue5 {
@@ -378,7 +386,6 @@ export class SubTypeSubValue6
   implements ISubTypeSubValue6, Webpb.WebpbMessage
 {
   value?: number | null;
-  webpbMeta: () => Webpb.WebpbMeta;
 
   static CLASS = "SubTypeSubValue6";
   static CONTEXT = "";
@@ -388,13 +395,15 @@ export class SubTypeSubValue6
   protected constructor(p?: ISubTypeSubValue6) {
     super();
     Webpb.assign(p, this, []);
-    this.webpbMeta = () =>
-      ({
-        class: "SubTypeSubValue6",
-        context: "",
-        method: "",
-        path: "",
-      }) as Webpb.WebpbMeta;
+  }
+
+  webpbMeta(): Webpb.WebpbMeta {
+    return {
+      class: SubTypeSubValue6.CLASS,
+      context: SubTypeSubValue6.CONTEXT,
+      method: SubTypeSubValue6.METHOD,
+      path: "",
+    };
   }
 
   static create(p?: ISubTypeSubValue6): SubTypeSubValue6 {


### PR DESCRIPTION
Resolve dynamic HTTP paths from the current message state instead of constructor arguments, and reuse static CLASS/CONTEXT/METHOD constants.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/jinganix/webpb/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
