### PR TITLE
fix: restore assign compatibility with Message class instances

### DIFF
--- a/runtime/ts/src/index.ts
+++ b/runtime/ts/src/index.ts
@@ -56,16 +56,47 @@ function toAliasedValue(value: unknown): unknown {
   return convert ? convert() : value;
 }
 
+function unwrapMessage(src: object): Record<string, unknown> {
+  const plain: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(src)) {
+    if (typeof value !== "function") {
+      plain[key] = value;
+    }
+  }
+  return plain;
+}
+
+function normalizeAssignSource(src: unknown): Record<string, unknown> | null {
+  if (src === null || src === undefined) {
+    return null;
+  }
+  if (isPlainObject(src)) {
+    return src;
+  }
+  if (typeof src !== "object" || Array.isArray(src)) {
+    return null;
+  }
+  const record = src as Record<string, unknown>;
+  if (typeof record.toWebpbAlias === "function") {
+    const aliased = record.toWebpbAlias.call(src);
+    if (isPlainObject(aliased)) {
+      return aliased;
+    }
+  }
+  return unwrapMessage(src);
+}
+
 export function assign(
   src: unknown,
   dest: unknown,
   excludes: readonly string[] = [],
 ): void {
-  if (!isPlainObject(src) || !isObject(dest)) {
+  const normalized = normalizeAssignSource(src);
+  if (!normalized || !isObject(dest)) {
     return;
   }
   const skip = new Set(excludes);
-  for (const [key, value] of Object.entries(src)) {
+  for (const [key, value] of Object.entries(normalized)) {
     if (value !== undefined && !skip.has(key)) {
       dest[key] = value;
     }

--- a/runtime/ts/test/index.test.ts
+++ b/runtime/ts/test/index.test.ts
@@ -42,6 +42,107 @@ describe("assign", () => {
     assign(src, dest, excludes);
     expect(dest).toStrictEqual(expected);
   });
+
+  it("should assign from plain object", () => {
+    // Given
+    const dest: Record<string, unknown> = {};
+
+    // When
+    assign({ code: 5, errors: {} }, dest);
+
+    // Then
+    expect(dest).toStrictEqual({ code: 5, errors: {} });
+  });
+
+  it("should assign from class instance with data fields", () => {
+    // Given
+    class ErrorMessage {
+      code?: number;
+      errors?: Record<string, unknown>;
+      webpbMeta = () => ({});
+    }
+    const src = Object.assign(new ErrorMessage(), { code: 5, errors: {} });
+    const dest: Record<string, unknown> = {};
+
+    // When
+    assign(src, dest);
+
+    // Then
+    expect(dest.code).toBe(5);
+    expect(dest.errors).toEqual({});
+    expect(dest.webpbMeta).toBeUndefined();
+  });
+
+  it("should assign from instance to instance via create pattern", () => {
+    // Given
+    class Msg {
+      code?: number;
+      errors?: Record<string, string>;
+      constructor(p?: Partial<Msg>) {
+        assign(p, this);
+      }
+    }
+    const src = new Msg({ code: 5, errors: {} });
+
+    // When
+    const dest = new Msg(src);
+
+    // Then
+    expect(dest.code).toBe(5);
+    expect(dest.errors).toEqual({});
+  });
+
+  it("should use toWebpbAlias when it returns plain object", () => {
+    // Given
+    class Msg {
+      code = 1;
+      toWebpbAlias() {
+        return { code: 5, errors: {} };
+      }
+      webpbMeta = () => ({});
+    }
+    const src = new Msg();
+    const dest: Record<string, unknown> = {};
+
+    // When
+    assign(src, dest);
+
+    // Then
+    expect(dest).toStrictEqual({ code: 5, errors: {} });
+  });
+
+  it("should unwrap instance when toWebpbAlias returns this", () => {
+    // Given
+    class Msg {
+      code = 5;
+      errors = {};
+      toWebpbAlias() {
+        return this;
+      }
+      webpbMeta = () => ({});
+    }
+    const src = new Msg();
+    const dest: Record<string, unknown> = {};
+
+    // When
+    assign(src, dest);
+
+    // Then
+    expect(dest.code).toBe(5);
+    expect(dest.errors).toEqual({});
+    expect(dest.webpbMeta).toBeUndefined();
+  });
+
+  it("should not assign from non-object", () => {
+    // Given
+    const dest: Record<string, unknown> = {};
+
+    // When
+    assign("x", dest);
+
+    // Then
+    expect(Object.keys(dest)).toHaveLength(0);
+  });
 });
 
 describe("getter", () => {


### PR DESCRIPTION
Normalize non-plain object sources by unwrapping data fields (skipping functions) so Message.create(instance) and cached instance reuse work again while keeping strict plain-object handling for JSON payloads.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/jinganix/webpb/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
