### PR TITLE
fix(runtime): export proto files

### DIFF
--- a/runtime/ts/package.json
+++ b/runtime/ts/package.json
@@ -45,7 +45,8 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
-    "./proto": "./proto"
+    "./proto": "./proto",
+    "./proto/*": "./proto/*"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Summary
- add a `./proto/*` export pattern for the TypeScript runtime package
- keep the existing `./proto` export unchanged

## Why
The `webpb@0.0.30` package publishes `.proto` files under `proto/`, but package exports only expose the directory itself:

```json
"./proto": "./proto"
```

With an `exports` map present, concrete proto files like `webpb/proto/google/protobuf/any.proto` are blocked by Node's package resolver:

```sh
node --input-type=module -e "import.meta.resolve('webpb/proto/google/protobuf/any.proto')"
# ERR_PACKAGE_PATH_NOT_EXPORTED
```

Adding `./proto/*` lets tools resolve the published proto assets directly.

## Validation
- parsed `runtime/ts/package.json`
- checked `webpb@0.0.30` tarball contains `proto/google/protobuf/any.proto`
- patched the installed tarball manifest locally and verified `import.meta.resolve('webpb/proto/google/protobuf/any.proto')` resolves to the packaged file
- `git diff --check`