### PR TITLE
feat(plugin): bundle protoc version and allow consumer override

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -57,10 +57,16 @@ gradlePlugin {
   }
 }
 
+val versionProtobufJava: String = gradleProperties.getProperty("versionProtobufJava")
+
 tasks.processResources {
   inputs.property("webpbVersion", version)
+  inputs.property("protobufVersion", versionProtobufJava)
   filesMatching("webpb-version.properties") {
-    expand("webpbVersion" to version)
+    expand(
+      "webpbVersion" to version,
+      "protobufVersion" to versionProtobufJava,
+    )
   }
 }
 

--- a/gradle-plugin/src/main/kotlin/io/github/jinganix/webpb/gradle/WebpbExtension.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/jinganix/webpb/gradle/WebpbExtension.kt
@@ -23,8 +23,11 @@ open class WebpbExtension {
   /** webpb artifact version; defaults to the Gradle plugin release version. */
   var webpbVersion: String? = null
 
-  /** {@code com.google.protobuf:protoc} version. */
-  var protobufVersion: String = "4.35.0"
+  /**
+   * {@code com.google.protobuf:protoc} version; defaults to the version bundled with the plugin.
+   * May also be set via the {@code webpb.protobufVersion} Gradle property.
+   */
+  var protobufVersion: String? = null
 
   /** Delete the protobuf output directory before each generation task runs. */
   var cleanOutput: Boolean = true

--- a/gradle-plugin/src/main/kotlin/io/github/jinganix/webpb/gradle/WebpbProtobufPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/jinganix/webpb/gradle/WebpbProtobufPlugin.kt
@@ -39,11 +39,12 @@ abstract class WebpbProtobufPlugin(
 
     project.afterEvaluate {
       val webpbVersion = extension.webpbVersion ?: WebpbVersions.pluginReleaseVersion()
+      val protobufVersion = resolveProtobufVersion(project, extension)
       val localPath = extension.localPluginPath ?: detectLocalPluginPath(project, protocArtifactId)
 
       project.extensions.configure<ProtobufExtension> {
         protoc {
-          artifact = "com.google.protobuf:protoc:${extension.protobufVersion}"
+          artifact = "com.google.protobuf:protoc:$protobufVersion"
         }
         plugins {
           clearGrpcPluginLocator(this)
@@ -89,6 +90,12 @@ abstract class WebpbProtobufPlugin(
     plugins: org.gradle.api.NamedDomainObjectContainer<GenerateProtoTask.PluginOptions>,
   ) {
     plugins.findByName("grpc")?.let(plugins::remove)
+  }
+
+  private fun resolveProtobufVersion(project: Project, extension: WebpbExtension): String {
+    return extension.protobufVersion
+      ?: project.findProperty("webpb.protobufVersion") as String?
+      ?: WebpbVersions.protobufVersion()
   }
 
   private fun detectLocalPluginPath(project: Project, protocArtifactId: String): String? {

--- a/gradle-plugin/src/main/kotlin/io/github/jinganix/webpb/gradle/WebpbVersions.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/jinganix/webpb/gradle/WebpbVersions.kt
@@ -21,10 +21,14 @@ package io.github.jinganix.webpb.gradle
 import java.util.Properties
 
 internal object WebpbVersions {
-  fun pluginReleaseVersion(): String {
+  private val properties: Properties by lazy {
     val stream =
       WebpbVersions::class.java.getResourceAsStream("/webpb-version.properties")
         ?: error("webpb-version.properties is missing from the Gradle plugin jar")
-    return Properties().apply { stream.use { load(it) } }.getProperty("webpbVersion")
+    Properties().apply { stream.use { load(it) } }
   }
+
+  fun pluginReleaseVersion(): String = properties.getProperty("webpbVersion")
+
+  fun protobufVersion(): String = properties.getProperty("protobufVersion")
 }

--- a/gradle-plugin/src/main/resources/webpb-version.properties
+++ b/gradle-plugin/src/main/resources/webpb-version.properties
@@ -1,1 +1,2 @@
 webpbVersion=${webpbVersion}
+protobufVersion=${protobufVersion}


### PR DESCRIPTION
## Summary
- Bundle the default `com.google.protobuf:protoc` version in `webpb-version.properties` from `gradle.properties` (`versionProtobufJava`) instead of hardcoding `4.35.0` in `WebpbExtension`.
- Let consumer projects override protoc via `webpb { protobufVersion = "..." }` or the `webpb.protobufVersion` Gradle property.

## Test plan
- [x] `./gradlew :gradle-plugin:build`
- [ ] CI passes on ubuntu/macos/windows

Made with [Cursor](https://cursor.com)